### PR TITLE
Clarify record object usage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+- Define default dereference depth guidelines for resolvers.

--- a/arns/arns-core-1.md
+++ b/arns/arns-core-1.md
@@ -34,11 +34,12 @@ The **ARNS-CORE-1** Specification includes the following requirements for valid,
 
 **Records Table**:
 
-- Must have a `Records` table containing `subDomains` and their associated `transactionId` and `ttlSeconds`.
+- Must have a `Records` table containing `subDomains` and their associated record values.
 - The `Records` object should be sorted alphabetically.
 - Each Record subdomain must be a string.
-- Each Record must include a `transactionId`, which is where this subdomain will point to.
-- Each Record must include a `ttlSeconds` value, which is the suggested time for caching by ArNS Name Resolvers.
+- Record values must be objects and may contain `txId`, `arns`, or both.
+  - When both `txId` and `arns` are supplied, resolution should prefer `arns`, falling back to `txId` if dereferencing the `arns` name fails.
+- Each record object must include a `ttlSeconds` value, which is the suggested time for caching by ArNS Name Resolvers.
 - The `ttlSeconds` value must not be less than 900 seconds.
 - `Records` must have a default Record, `@`, which points to an Arweave Transaction ID.
 - `UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk` can be used as a placeholder Transaction ID.
@@ -72,7 +73,7 @@ The **ARNS-CORE-1** specification includes all the objects needed to support ArN
 ```
 Records = Records or {
     ["@"] = {
-        transactionId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
+        txId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
         ttlSeconds = 3600
     }
 }

--- a/arns/arns-manage-1.md
+++ b/arns/arns-manage-1.md
@@ -58,7 +58,7 @@ Controllers = Controllers or { Owner }
 -- ARNS-CORE-1 Objects
 Records = Records or {
   ["@"] = {
-    transactionId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
+    txId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
     ttlSeconds = 3600
   }
 }
@@ -260,23 +260,24 @@ Send({
 
 #### Set-Record
 
-Updates an existing undername’s Sub-Domain in the Records table, including modifying the transaction id and time to live.
+Updates an existing undername’s Sub-Domain in the Records table. Records may reference a transaction ID, another ArNS name, or both.
 
 Executable by the process Owner or an authorized user in the Controllers table.
 
 ##### Parameters
 
-| Name           | Type   | Description                                                                                 |
-| -------------- | ------ | ------------------------------------------------------------------------------------------- |
-| Sub-Domain     | string | The undername record to update, e.g., `@`, `ardrive`, or `dapp_ardrive`                     |
-| Transaction-Id | string | The Arweave transaction ID that this undername points to.                                   |
-| TTL-Seconds    | string | The time to live for this record, indicating how long an ArNS Resolver should cache it for. |
+| Name           | Type   | Description |
+| -------------- | ------ | -------------------------------- |
+| Sub-Domain     | string | The undername record to update, e.g., `@`, `ardrive`, or `dapp_ardrive` |
+| Tx-Id          | string | *(Optional)* The Arweave transaction ID this undername points to. |
+| Arns           | string | *(Optional)* Another ArNS name to dereference, e.g., `dapp_ardrive` |
+| TTL-Seconds    | string | The time to live for this record, indicating how long an ArNS Resolver should cache it. |
 
 ##### Rules
 
 - Must be an authorized process `Owner` or `Controller`.
 - Must specify a valid `Sub-Domain` parameter (string) as a message tag.
-- Must specify a valid `Transaction-Id` parameter (string) as a message tag.
+- Must supply either a `Tx-Id` tag, an `Arns` tag, or both.
 - Must specify a valid `TTL-Seconds` parameter (string) as a message tag, which is an integer between 60 and 86400.
 - The undername’s `Sub-Domain` must already exist in the `Records` table.
 - Must add `X-`forwarded tags to the response notice.
@@ -288,7 +289,8 @@ Send({
   Target = "{Process Identifier}",
   Action = "Set-Record",
   ["Sub-Domain"] = "foo",
-  ["Transaction-Id"] = "{Base64 URL}",
+  ["Tx-Id"] = "{Base64 URL}",
+  ["Arns"] = "dapp_ardrive",
   ["TTL-Seconds"] = "60"
 })
 ```
@@ -325,10 +327,11 @@ Send({
 {
   Target = msg.From,
   Action = "Set-Record-Notice",
-  Data = json.encode({
-    transactionId = transactionId,
-    ttlSeconds = ttlSeconds,
-  }),
+    Data = json.encode({
+      txId = txId,
+      arns = arns,
+      ttlSeconds = ttlSeconds,
+    }),
   ... other forwarded tag name and value pairs
 }
 ```

--- a/arns/arns-overview.md
+++ b/arns/arns-overview.md
@@ -66,7 +66,7 @@ Registering a name requires spending IO tokens corresponding to the name’s cha
 
 ### Arweave Name Tokens (ANTs)
 
-Arweave Name Tokens (ANTs) are specialized AO Processes that manage the ownership, configuration, and data pointer records for names registered in ArNS. They facilitate the mapping of names to various types of Permaweb data—whether a webpage, dApp, or file—through their respective Arweave transaction IDs. They can be transferred as needed, like any other non-fungible token.
+Arweave Name Tokens (ANTs) are specialized AO Processes that manage the ownership, configuration, and data pointer records for names registered in ArNS. They facilitate the mapping of names to various types of Permaweb data—whether a webpage, dApp, or file—by referencing either Arweave transaction IDs or other ArNS names. They can be transferred as needed, like any other non-fungible token.
 
 - **Process Control**: Each registered ArNS name points to the Process ID of an ANT. The owner of this ANT controls how the ArNS name functions. ANT owners can upgrade their processes as needed, or they can set the process Owner to null, rendering the process code immutable.
 - **Resolution**: AR.IO Gateways and other ArNS Resolvers read the state from these registered ANTs to properly resolve and serve the data they reference.

--- a/arns/arns-resolver-1.md
+++ b/arns/arns-resolver-1.md
@@ -33,6 +33,7 @@ The resolver must adhere to the following protocols to correctly identify, resol
   - The maximum length of each label is 63 characters, and a full domain name can have a maximum of 253 characters.
 - **Root Record**: The Record `"@"` is used for the root of the ArNS Name. All undernames for a given name must be sorted alphabetically, with the root `@` being at the top.
 - **Regex Compliance**: Must not serve undernames that don't match the ArNS standard regex pattern.
+- **Record Values**: Records may reference an Arweave transaction ID, another ArNS name, or both. When both are present the resolver should prefer the `arns` value and only fall back to the `txId` if dereferencing fails.
 - **Caching**:
   - Must cache each undername for the time-to-live (TTL) associated with it.
   - The minimum TTL is 900 seconds (15 minutes).
@@ -64,6 +65,10 @@ If the process does not respond to the State request, the resolver will be unabl
 #### 3. Local Storage of Data
 
 The resolver should store all retrieved information locally to facilitate easy lookups by users or downstream infrastructure, such as an AR.IO Gateway.
+
+#### 4. Dereferencing ArNS Records
+
+When a record specifies an `arns` value, the resolver must continue resolving that name internally until it produces a transaction ID. This internal resolution is known as **dereferencing** and must not rely on HTTP redirects. Resolvers may set their own maximum dereference depth and should use a Set-like structure to track visited names to detect loops. If a loop is detected or dereferencing fails, the resolver should fall back to the record's `txId` value if available. If no `txId` can be used, resolution must fail.
 
 ### Performance and Compliance
 

--- a/arns/arns-token-1.md
+++ b/arns/arns-token-1.md
@@ -110,7 +110,7 @@ Controllers = Controllers or { Owner }
 -- ARNS-CORE-1 Objects
 Records = Records or {
   ["@"] = {
-    transactionId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
+    txId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
     ttlSeconds = 3600
   }
 }


### PR DESCRIPTION
## Summary
- enforce that record values are objects and may include `txId` and `arns`
- clean up TODO list

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684920461078832d9d1135f593dd7871