### PR TITLE
docs(arns): rewrite specs for Solana migration (v2.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AR.IO Network Specifications
 
-Welcome to the AR.IO Network Specifications repository! This repository contains the official specifications for building on the AR.IO Network, a decentralized gateway network for interacting with Arweave. These specifications are designed to create a unified, interoperable, and resilient ecosystem of tools and applications built that leverage the various protocols and services offered by the AR.IO Network.
+Welcome to the AR.IO Network Specifications repository! This repository contains the official specifications for building on the AR.IO Network, a decentralized gateway network for accessing Arweave and other decentralized storage protocols. These specifications are designed to create a unified, interoperable, and resilient ecosystem of tools and applications that leverage the various protocols and services offered by the AR.IO Network.
 
 ## Overview
 
-The AR.IO Network Specifications cover a range of critical functionality, from the Arweave Name System (ArNS) to routing and path manifest handling. By adhering to these specs, developers can build reliable, scalable applications that integrate seamlessly with the AR.IO Gateway network and the broader Arweave ecosystem.
+The AR.IO Network Specifications cover a range of critical functionality, from the AR.IO Name System (ArNS) to path manifest handling. By adhering to these specs, developers can build reliable, scalable applications that integrate seamlessly with the AR.IO Gateway network and the broader permaweb ecosystem.
 
 ### Why Specifications Matter
 
@@ -16,19 +16,25 @@ Specifications provide the foundational structure for the AR.IO Network. They en
 
 ## Specifications
 
-### Arweave Name System (ArNS)
+### AR.IO Name System (ArNS)
 
-- **ARNS-CORE**: Core specification for resolving Arweave Names to transaction IDs.
-- **ARNS-MANAGE**: Control and management features for Arweave Names.
-- **ARNS-TOKEN**: Adds token functionality, including transferability and metadata.
+The ArNS specs define how human-readable names map to content across Arweave, IPFS, and future storage protocols. The reference implementation is a set of Solana programs (`ario-arns`, `ario-ant`, `ario-core`); AR.IO Name Tokens (ANTs) are Metaplex Core NFTs. Start with the overview if you're new to the system.
 
-### Routing and URI Handling
-
-- **ARNS-ROUTING**: Defines the AR.IO Wayfinder Protocol for routing to Arweave Names and content.
+- **[ARNS-OVERVIEW](./arns/arns-overview.md)**: Umbrella reference — system architecture, name lifecycle, primary names, name validation, program IDs lookup, account serialization, and event surface.
+- **[ARNS-CORE-1](./arns/arns-core-1.md)**: Record format and read interface for resolving names to multi-protocol content addresses (Arweave TX IDs, IPFS CIDs).
+- **[ARNS-MANAGE-1](./arns/arns-manage-1.md)**: Record creation, controller delegation, record-level ownership, and AR.IO Network integration (release, reassign, primary names).
+- **[ARNS-TOKEN-1](./arns/arns-token-1.md)**: AR.IO Name Tokens as Metaplex Core NFTs with on-chain configuration, controllers, and undername records.
+- **[ARNS-RESOLVER-1](./arns/arns-resolver-1.md)**: Resolver/gateway protocol — direct on-chain reads, multi-protocol routing, URI schemes (`ar://`, `ipfs://`), response headers, caching, and observation compliance.
 
 ### Path Manifest Specification
 
-- **PATH-MANIFEST-SCHEMA**: JSON-based schema for mapping paths to content within Arweave.
+- **[PATH-MANIFEST-SCHEMA](./manifests/path-manifest-schema.md)**: JSON-based schema for mapping paths to content within Arweave.
+
+### Reference Implementations
+
+- [`ar-io-solana-contracts`](https://github.com/ar-io/ar-io-solana-contracts) — the four Solana programs (`ario-core`, `ario-gar`, `ario-arns`, `ario-ant`) that back the ArNS specs. The published Anchor IDLs are the authoritative source for program IDs, account layouts, instruction signatures, and event schemas.
+- [`@ar.io/sdk`](https://github.com/ar-io/ar-io-sdk) — TypeScript SDK with kit-native Solana transport and (legacy) AO support. Exports `ARIO_*_PROGRAM_ID` constants mirroring the IDLs.
+- [`ar-io-node`](https://github.com/ar-io/ar-io-node) — reference AR.IO Gateway implementation; ships with an ArNS resolver per ARNS-RESOLVER-1.
 
 ## Specification Principles and Practices
 
@@ -62,7 +68,7 @@ For example:
 
 We welcome contributions! Here’s how you can get involved:
 
-- **Review Existing Specs**: Explore the /specs folder to get familiar with the structure.
+- **Review Existing Specs**: Explore the `arns/` and `manifests/` folders to get familiar with the structure.
 - **Open Issues**: If you spot inconsistencies or have suggestions, open an issue here.
 - **Submit a Pull Request**: Fork the repo, create a branch, and submit a pull request. Ensure your changes follow the principles outlined above.
 

--- a/arns/arns-core-1.md
+++ b/arns/arns-core-1.md
@@ -1,191 +1,320 @@
 # ARNS-CORE-1
 
-## Status:
+## Status
 
-**In-Review**
+**Draft**
 
-## Version:
+## Version
 
 | Version | Description                                           | Date       |
 | ------- | ----------------------------------------------------- | ---------- |
 | 1.0.0   | Initial version of the **ARNS-CORE-1** specification. | 2024-09-01 |
 | 1.1.0   | Added priority field to Records object.               | 2025-07-29 |
+| 2.0.0   | Rewrite for Solana: on-chain PDA records, multi-protocol targets, renamed fields, SDK/RPC interface. | 2026-04-20 |
+| 2.1.0   | Pluggable ANT program: record PDAs are derived against the program named in the asset's Metaplex Core Attributes plugin (`ANT Program` key). Canonical fallback when absent. | 2026-05-03 |
+| 2.1.1   | Audit corrections: keyword/description limits (8 / 256), AntRecordMetadata PDA split, sort/index is read-side, async `ANT.init`. | 2026-05-11 |
+| 2.1.2   | Pinned `ANT Program` plugin key/value encoding; Get State naming note. | 2026-05-11 |
 
 ## Abstract
 
-The **ARNS-CORE-1** specification defines the foundational processes required for resolving Arweave Name System (ArNS) names to their corresponding Arweave Transaction IDs and Owners. It provides the essential framework upon which other functionalities and extensions are built, ensuring consistent name resolution across the AR.IO network.
+The **ARNS-CORE-1** specification defines the foundational requirements for resolving AR.IO Name System (ArNS) names to their corresponding content addresses and owners. It provides the essential framework upon which other functionalities and extensions are built, ensuring consistent name resolution across the AR.IO network.
+
+On Solana, each AR.IO Name Token (ANT) is a Metaplex Core NFT. Its undername records are stored as individual on-chain PDA accounts derived from the NFT mint address and the undername. Reading records is done via Solana RPC account reads or through the AR.IO SDK.
 
 ## Motivation
 
-The **ARNS-CORE-1** specification provides the essential building blocks for resolving Arweave Names within the Arweave Name System (ArNS). It defines the minimal structure and processes needed to map human-readable names to Arweave Transaction IDs, ensuring consistent and reliable name resolution across AR.IO gateways.
+The **ARNS-CORE-1** specification provides the essential building blocks for resolving AR.IO Names within the AR.IO Name System (ArNS). It defines the minimal structure and interface needed to map human-readable names to content addresses, ensuring consistent and reliable name resolution across AR.IO gateways.
 
-This specification establishes a standardized record format and a set of core handlers that are crucial for any ArNS implementation. By adhering to these foundational requirements, developers can build additional functionalities on top of a stable and predictable resolution framework, ensuring interoperability and ease of use within the Arweave ecosystem.
+This specification establishes a standardized record format and a read interface that are crucial for any ArNS implementation. By adhering to these foundational requirements, developers can build additional functionalities on top of a stable and predictable resolution framework, ensuring interoperability and ease of use within the AR.IO ecosystem.
 
-### Language of Implementation
+### Implementation Note
 
-All examples and code snippets in this specification are written in Lua. This choice ensures compatibility with the AO Processes and the Arweave ecosystem.
+This specification is implementation-agnostic. The canonical implementation stores records as Solana PDA accounts within the `ario-ant` program, and the AR.IO SDK provides a unified read interface. However, the rules and validation constraints defined here apply to all implementations and all ArNS name resolvers.
 
-However, developers are not restricted to using Lua exclusively when building new features or extending functionalities around ArNS. While Lua is recommended for direct integration with existing infrastructure, other programming languages can be used, provided they adhere to the protocols and specifications outlined in this document.
+The program holding an ANT's per-mint state PDAs is declared by an `ANT Program` entry in the asset's Metaplex Core Attributes plugin. Resolvers MUST read this entry to find the program ID and derive `AntRecord` PDAs against it; absence (or any parse failure) MUST fall back to the canonical `ARIO_ANT_PROGRAM_ID`. This makes the ANT program pluggable per-asset (BYO-ANT) without changing the registry-side `ArnsRecord` schema. See ADR-016 / BD-100.
+
+The plugin entry is a Metaplex Core Attribute key/value pair with:
+
+| Field | Value |
+| --- | --- |
+| `key`   | `"ANT Program"` (exact string, case-sensitive, single space between words) |
+| `value` | The ANT program's address as a base58-encoded string (e.g., `"ARioAntProg..."`)         |
+
+```ts
+// Resolver pattern (kit-style)
+const asset = await fetchEncodedAccount(rpc, antMint).send();
+const antProgram = readAttribute(asset.data, 'ANT Program') ?? ARIO_ANT_PROGRAM_ID;
+const [recordPda] = await getProgramDerivedAddress({
+  programAddress: antProgram,
+  seeds: [
+    Buffer.from('ant_record'),
+    addressEncoder.encode(antMint),
+    sha256(undername.toLowerCase()),
+  ],
+});
+```
 
 ## Specification
 
 ### Overview
 
-The **ARNS-CORE-1** Specification includes the following requirements for valid, resolvable Records:
+The **ARNS-CORE-1** specification includes the following requirements for valid, resolvable records:
 
-**Records Table**:
+**Records**:
 
-- Must have a `Records` table containing `subDomains` and their associated `transactionId`, `ttlSeconds`, and optional `priority`.
-- The `Records` object should be sorted alphabetically.
-- Each Record subdomain must be a string.
-- Each Record must include a `transactionId`, which is where this subdomain will point to.
-- Each Record must include a `ttlSeconds` value, which is the suggested time for caching by ArNS Name Resolvers.
-- The `ttlSeconds` value must not be less than 900 seconds.
-- Each Record may include a `priority` value, which determines the sort order of undernames served by gateways.
-- The `priority` value for the default record `@` must be 0.
-- The `priority` value for other records must be an integer greater than 0 or nil.
-- `UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk` can be used as a placeholder Transaction ID.
-- The Record subdomain plus its ArNS name must not be longer than 63 characters.
-- The Record subdomain must pass the following regular expression: `RegExp("^[a-zA-Z0-9_-]+$")`.
+- Each ANT MUST have at least one record: the root record identified by the undername `@`.
+- Each record is identified by an **undername** (e.g., `@`, `blog`, `docs_v2`).
+- Each record MUST include a `target`, which is the content address this undername resolves to.
+- Each record MUST include a `targetProtocol`, which identifies the protocol used to retrieve the content at `target`.
+- Each record MUST include a `ttlSeconds` value, which is the suggested time-to-live for caching by ArNS name resolvers.
+- The `ttlSeconds` value MUST be between 60 and 86400 seconds (inclusive). Resolvers SHOULD cache for at least 900 seconds regardless of the declared TTL.
+- Each record MAY include a `priority` value, which determines the sort order of undernames served by gateways.
+- The `priority` value for the root record (`@`) MUST be 0.
+- The `priority` value for non-root records MUST be an integer greater than 0, or omitted (unset). When omitted, the record is sorted lexicographically after all priority-assigned records.
+- The undername `@` denotes the root/base name record (i.e., the ArNS name itself with no subdomain prefix).
+- The record undername plus its ArNS name MUST NOT exceed 63 characters in total length.
+- Non-root undernames MUST match the regular expression `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` (must start with an alphanumeric character; remaining characters may be alphanumeric, hyphens, or underscores).
+- Records SHOULD be sorted by priority (ascending), then lexicographically by undername for records without a priority.
 
-**Handlers**:
+**Target and Target Protocol**:
 
-- Must include handlers to read a single `Record` and multiple `Records`.
-- Must include a handler to read the `State` of the ANP, which includes all `Records` and the current `Owner`.
+- The `target` field is a content address string with a maximum length of 128 characters.
+- The `targetProtocol` field is an integer that identifies how to interpret and retrieve the content at `target`.
+- Defined protocol values:
+
+  | Value | Protocol | Target Format | Example |
+  | ----- | -------- | ------------- | ------- |
+  | 0     | Arweave  | 43-character base64url Arweave transaction ID | `UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk` |
+  | 1     | IPFS     | CIDv0 (`Qm...`, exactly 46 chars) or CIDv1 (multibase-prefixed) | `QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG` (CIDv0) / `bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi` (CIDv1) |
+
+- Protocol values 2 and above are reserved for future use.
+- When `targetProtocol` is 0 (Arweave), the `target` MUST be a valid 43-character base64url string (character set: `[a-zA-Z0-9_-]`).
+- When `targetProtocol` is 1 (IPFS), the `target` MUST be a valid CID — either CIDv0 (exactly 46 chars, `Qm` prefix, base58btc body) or CIDv1 (multibase-prefixed, alphanumeric body).
+- `UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk` MAY be used as a placeholder target for the Arweave protocol (protocol 0).
+
+**Interface**:
+
+- Implementations MUST provide a way to read a single record by undername.
+- Implementations MUST provide a way to read all records for an ANT.
+- Implementations MUST provide a way to read the state of the ANT, which includes all records, the current owner, and controller list.
 
 **Resolvability**:
 
-Arweave Name owners can configure their process code and parameters as they wish, but all of the above rules are also enforced at each ArNS Name Resolver that is part of AR.IO Gateways.
+AR.IO Name owners can configure their ANT records as they wish, but all of the above rules are also enforced at each ArNS name resolver that is part of AR.IO gateways.
 
-Primarily, any Arweave Name that is to be resolved by the AR.IO Network must have an active registration in the ArNS Registry. Additionally, Records within the Arweave Name process must be valid, or else ArNS Resolvers or AR.IO Gateways may not resolve them.
+Any AR.IO Name that is to be resolved by the AR.IO network MUST have an active registration in the ArNS Registry. Additionally, records within the ANT MUST be valid, or else ArNS resolvers and AR.IO gateways MAY refuse to resolve them.
 
-Arweave Names may not be resolvable under the following scenarios:
+AR.IO Names may not be resolvable under the following scenarios:
 
-- Poor performing code.
-- Invalid records or malformed state.
-- Broken handlers, incorrect handler responses, or conflicting process code.
-- Subdomains exceeding the amount paid for (registered) within the ArNS Registry.
+- Invalid records or malformed state (e.g., missing `target`, invalid `targetProtocol`, TTL out of range).
+- Undernames exceeding the amount paid for (registered) within the ArNS Registry.
+- The ANT account does not exist on-chain or is not owned by the expected program.
+- The record PDA does not exist or cannot be deserialized.
 
 ### Objects
 
-The **ARNS-CORE-1** specification includes all the objects needed to support ArNS Name resolution.
-
-#### ARNS-CORE-1 Objects
-
-```
-Records = Records or {
-    ["@"] = {
-        transactionId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
-        ttlSeconds = 3600,
-        priority = 0
-    }
-}
-```
-
-### Handlers
-
-#### Action Map
-
-The following actions are handled in the **ARNS-CORE-1** specification:
-
-```
-ARNSCoreSpecActionMap = {
-    -- read actions
-    Record = "Record",
-    Records = "Records",
-    State = "State",
-}
-```
+The **ARNS-CORE-1** specification defines the following objects needed to support ArNS name resolution.
 
 #### Record
 
-Retrieves the ID and time to live (seconds) for an undername contained in the `Records` table. Executable by anonymous users.
+A record represents a single undername resolution entry within an ANT. On Solana, each record is stored as two PDA accounts under the ANT program:
+
+- **`AntRecord`** — required fields (resolution-critical). Seeds: `["ant_record", <mint>, <undername_hash>]`.
+- **`AntRecordMetadata`** — optional descriptive fields (display name, logo, description, keywords). Seeds: `["ant_record_meta", <mint>, <undername_hash>]`. Created lazily on first write to an optional field.
+
+`<mint>` is the Metaplex Core NFT public key and `<undername_hash>` is the SHA-256 hash of the lowercased undername. Resolvers MAY skip reading the metadata PDA if they only need core resolution data; the logical "Record" presented below is the union of both accounts.
+
+**Required fields:**
+
+| Field            | Type          | Description |
+| ---------------- | ------------- | ----------- |
+| `undername`      | string        | The undername identifier (`@` for root, or a valid subdomain label). Stored lowercase. Max 61 characters. |
+| `target`         | string        | Content address (Arweave TX ID, IPFS CID, etc.). Max 128 characters. |
+| `targetProtocol` | integer (u8)  | Protocol identifier for content retrieval. `0` = Arweave, `1` = IPFS. |
+| `ttlSeconds`     | integer (u32) | Time-to-live in seconds for resolver caching. Range: 60-86400. |
+
+> **SDK property naming note:** The AR.IO SDK exposes `target` as `transactionId` in its TypeScript interface for backward compatibility with the AO-era API. The on-chain Borsh field is `target`; the SDK property is `transactionId`. Both refer to the same value. The `targetProtocol` name is consistent across the on-chain schema and the SDK.
+
+**Optional fields:**
+
+| Field         | Type             | Description |
+| ------------- | ---------------- | ----------- |
+| `priority`    | integer (u32) or null | Sort order. `0` required for `@`, `>0` for others, `null`/omitted for lexicographic ordering. |
+| `owner`       | string or null   | Delegated record owner address. When set, this address can modify the record independently of the ANT owner. |
+| `displayName` | string or null   | Human-readable display name. Max 61 characters. |
+| `logo`        | string or null   | Logo image address (Arweave TX ID, 43 characters). |
+| `description` | string or null   | Free-text description. Max 256 characters. |
+| `keywords`    | array of strings or null | Keyword tags. Max 8 keywords, each max 32 characters. |
+
+#### Record Examples
+
+**Root record with Arweave target:**
+
+```
+{
+  "undername": "@",
+  "target": "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
+  "targetProtocol": 0,
+  "ttlSeconds": 3600,
+  "priority": 0
+}
+```
+
+**Undername record with IPFS target:**
+
+```
+{
+  "undername": "docs",
+  "target": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+  "targetProtocol": 1,
+  "ttlSeconds": 900,
+  "priority": 1
+}
+```
+
+**Undername record with Arweave target and optional metadata:**
+
+```
+{
+  "undername": "blog",
+  "target": "bNaUFJlfMQ0uqBamLkhNKF96DGCo3bE-5_0Lx3EXAMPLE",
+  "targetProtocol": 0,
+  "ttlSeconds": 1800,
+  "priority": 2,
+  "displayName": "My Blog",
+  "description": "Personal blog hosted on Arweave",
+  "keywords": ["blog", "arweave", "permanent"]
+}
+```
+
+### Interface
+
+The following read operations are defined by the **ARNS-CORE-1** specification. Implementations MUST support all three.
+
+#### Get Record
+
+Retrieves a single record by undername. Executable by any reader (no authentication required).
 
 ##### Parameters
 
-| Name       | Type   | Description                                                               |
-| ---------- | ------ | ------------------------------------------------------------------------- |
-| Sub-Domain | string | The undername record to retrieve, e.g., `@`, `ardrive`, or `dapp_ardrive` |
+| Name      | Type   | Required | Description |
+| --------- | ------ | -------- | ----------- |
+| undername  | string | Yes      | The undername to look up (e.g., `@`, `blog`, `docs_v2`). |
 
-##### Rules
+##### Behavior
 
-- Must specify a valid `Sub-Domain` parameter (string) as a message tag.
-- The name must exist in the `Records` table.
-- Must add `X-`forwarded tags to the response notice.
+- If the record exists, return it with all fields (required and optional).
+- If the record does not exist, return `undefined` / `null` / an empty result (implementation-dependent).
 
-##### Action
+##### SDK Example
 
-```
-Send({
-    Target = "{Process Identifier}",
-    Action = "Record",
-    ["Sub-Domain"] = "foo"
-})
-```
+```typescript
+import { ANT } from '@ar.io/sdk';
+import { createSolanaRpc, mainnet } from '@solana/kit';
 
-##### Responses
+const rpc = createSolanaRpc(mainnet('https://api.mainnet-beta.solana.com'));
 
-**Invalid Record**
+const ant = await ANT.init({
+  backend: 'solana',
+  processId: '<ant-mint-address>',
+  rpc,
+});
 
-```
-{
-    Target = msg.From,
-    Action = "Invalid-Record-Notice",
-    Data = nameRes,
-    Error = "Record-Error",
-    ["Message-Id"] = msg.Id,
-}
+// Read the root record
+const rootRecord = await ant.getRecord({ undername: '@' });
+// => { transactionId: "UyC5P5...", targetProtocol: 0, ttlSeconds: 3600, priority: 0 }
+
+// Read a specific undername
+const docsRecord = await ant.getRecord({ undername: 'docs' });
+// => { transactionId: "bafybei...", targetProtocol: 1, ttlSeconds: 900, priority: 1 }
 ```
 
-**Valid Record**
+##### Direct RPC Example (Solana)
 
+Record PDA derivation: `["ant_record", <mint_pubkey>, SHA256(lowercase(undername))]` under the `ario-ant` program.
+
+```typescript
+import {
+  address,
+  fetchEncodedAccount,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+} from '@solana/kit';
+
+const [recordPDA] = await getProgramDerivedAddress({
+  programAddress: ARIO_ANT_PROGRAM_ID,
+  seeds: [
+    'ant_record',
+    getAddressEncoder().encode(mintAddress),
+    sha256(undername.toLowerCase()),
+  ],
+});
+
+const account = await fetchEncodedAccount(rpc, recordPDA);
+// Deserialize account.data per the AntRecord account layout
 ```
-{
-    Target = msg.From,
-    Action = "Record-Notice",
-    Name = msg.Tags["Sub-Domain"],
-    Data = json.encode(Records[name]),
-    ... other forwarded tag name and value pairs
-}
-```
 
-#### State
+#### Get Records
 
-Returns specific information about the state of the **ARNS-CORE-1** process, including all `Records` and its current `Owner`. Executable by anonymous users.
+Retrieves all records for an ANT. Returns a map of undername to record, sorted by priority (ascending) then lexicographically. Each entry includes an `index` field indicating its position in the sorted order. Executable by any reader.
+
+> **Note.** Sort order and the `index` field are computed at read time by the SDK or resolver. On-chain, each record is a standalone PDA with no enforced ordering — the program does not store or emit an index.
 
 ##### Parameters
 
-No parameters necessary.
+None.
 
-##### Rules
+##### Behavior
 
-- Must return a state object as JSON in the data field of the response notice.
-- The state object must include:
-  - The entire `Records` table as JSON.
-  - The current process `Owner`.
-- Must add `X-`forwarded tags to the response notice.
+- Return all records for the ANT as a map keyed by undername.
+- Records MUST be sorted: priority-assigned records first (ascending by priority value), followed by records without a priority (sorted lexicographically by undername).
+- Each record in the result includes an `index` field (integer, 0-based) reflecting its position in the sorted order.
 
-##### Action
+##### SDK Example
 
+```typescript
+const records = await ant.getRecords();
+// => {
+//   "@":    { transactionId: "UyC5P5...", targetProtocol: 0, ttlSeconds: 3600, priority: 0, index: 0 },
+//   "docs": { transactionId: "bafybei...", targetProtocol: 1, ttlSeconds: 900, priority: 1, index: 1 },
+//   "blog": { transactionId: "bNaUFJ...", targetProtocol: 0, ttlSeconds: 1800, priority: 2, index: 2 },
+//   "api":  { transactionId: "xR3kLP...", targetProtocol: 0, ttlSeconds: 60, index: 3 }
+// }
 ```
-Send({
-    Target = "{Process Identifier}",
-    Action = "State"
-})
-```
 
-##### Responses
+#### Get State
 
-**Valid `State`**
+Returns the complete state of the ANT, including all records, the current owner, and the controller list. Executable by any reader.
 
-```
-{
-    Target = msg.From,
-    Action = "State-Notice",
-    Data = json.encode({
-        Records = Records,
-        Owner = ao.env.Process.Owner,
-    }),
-    ... other forwarded tag name and value pairs
-}
+> **SDK property naming note:** The SDK preserves the legacy AO-era field naming (`Owner`, `Controllers`, `Records`, `Name`, `Ticker`, `Logo`, `Description`, `Keywords`) in this composed view for backward compatibility. The underlying on-chain fields are snake_case (e.g., `last_known_owner`); the SDK aggregates and renames them at read time.
+
+##### Parameters
+
+None.
+
+##### Behavior
+
+- Return a state object containing:
+  - `Owner` -- the current owner address of the ANT (the Metaplex Core NFT holder).
+  - `Controllers` -- the list of authorized controller addresses.
+  - `Records` -- all records (same format as Get Records, but without the `index` field).
+  - Additional ANT metadata: `Name`, `Ticker`, `Logo`, `Description`, `Keywords`.
+
+##### SDK Example
+
+```typescript
+const state = await ant.getState();
+// => {
+//   Owner: "5fSD3...",
+//   Controllers: ["5fSD3...", "7xKL2..."],
+//   Records: {
+//     "@":    { transactionId: "UyC5P5...", targetProtocol: 0, ttlSeconds: 3600, priority: 0 },
+//     "docs": { transactionId: "bafybei...", targetProtocol: 1, ttlSeconds: 900, priority: 1 }
+//   },
+//   Name: "my-name",
+//   Ticker: "ANT-MY-NAME",
+//   Logo: "Sie_26dvGYXLv7c9S4wznlmswoIenDpCY...",
+//   Description: "My AR.IO Name Token",
+//   Keywords: ["example", "ario"]
+// }
 ```

--- a/arns/arns-manage-1.md
+++ b/arns/arns-manage-1.md
@@ -2,7 +2,7 @@
 
 ## Status:
 
-**In-Review**
+**Draft**
 
 ## Version:
 
@@ -11,876 +11,530 @@
 | 1.0.0   | Initial version of the **ARNS-MANAGE-1** specification. | 2024-09-01 |
 | 1.1.0   | Added AR.IO Network handlers, Priority parameter for Set-Record, Initialized field, and boot handler documentation. | 2025-07-29 |
 | 1.2.0   | Added undername ownership with Transfer-Record handler, record metadata fields, and delegated permission model for record owners. | 2025-08-01 |
+| 2.0.0   | Rewritten for Solana. ANTs are Metaplex Core NFTs. Owner = NFT holder. Controllers stored in on-chain PDA. Record owner delegation model. AR.IO Network integration instructions moved to ario-arns / ario-core programs. Boot handler removed. | 2026-04-20 |
+| 2.1.0   | Pluggable ANT program: management instructions live on the program named in the asset's `ANT Program` Attributes-plugin entry. Conformance is on the third-party program. | 2026-05-03 |
+| 2.1.1   | Audit corrections: ADR-016 authorization model for registry-side instructions (caller matches stored `owner`, not current NFT holder), `AntRecordMetadata` PDA split, description max 256, keywords max 8, `reassign_name` parameter clarification. | 2026-05-11 |
+| 2.1.2   | Documented full primary-name flow (`request_primary_name`, `remove_primary_name`); added Primary Names concept section and PDA seeds. | 2026-05-11 |
 
 ## Abstract
 
-The **ARNS-MANAGE-1** specification introduces additional management and control utilities for Arweave Names. It provides the necessary handlers for adding, modifying, and removing records, as well as managing controllers who can add, set or remove these records. Additionally, it supports delegated ownership of individual undernames, enabling record-level control while maintaining ANT owner authority.
+The **ARNS-MANAGE-1** specification defines the management and control operations for AR.IO Name Tokens (ANTs). It covers undername record creation, modification, and removal; controller delegation for shared record management; and integration with the AR.IO Network for name release, reassignment, and primary name operations.
+
+On Solana, each ANT is a Metaplex Core NFT. Ownership is determined by who holds the NFT -- there is no stored `Owner` variable. Extended state (configuration, controllers, records) is stored in Program Derived Accounts (PDAs) keyed to the NFT mint address.
+
+The program that owns these PDAs is declared per-asset in the Metaplex Core Attributes plugin under the `ANT Program` key (set at `CreateV1` time by the SDK and migration mint paths). Implementations of this specification SHOULD treat that key as the routing target: derive every management PDA against it and, on absence, fall back to the canonical `ARIO_ANT_PROGRAM_ID`. Third-party programs that wish to plug into the AR.IO Name System MUST conform to the management instruction surface defined here AND mint their assets with `ANT Program: <their_program_id>` in the Attributes plugin so resolvers can route correctly. See ADR-016 / BD-100 for the full design.
 
 ## Motivation
 
-The **ARNS-MANAGE-1** specification builds on the foundational **ARNS-CORE-1** by adding essential management capabilities. As Arweave Names require ongoing updates and adjustments, this specification ensures that process owners have the tools needed to manage records and delegate control to other users securely. This includes the ability to assign ownership of individual undernames to specific users while maintaining the ANT owner's ultimate authority. By standardizing these management operations, **ARNS-MANAGE-1** enables efficient and consistent name management across the Arweave ecosystem.
-
-#### Language of Implementation
-
-All examples and code snippets in this specification are written in Lua. This choice ensures compatibility with the AO Processes and the Arweave ecosystem.
-
-However, developers are not restricted to using Lua exclusively when building new features or extending functionalities around ArNS. While Lua is recommended for direct integration with existing infrastructure, other programming languages can be used, provided they adhere to the protocols and specifications outlined in this document.
+The **ARNS-MANAGE-1** specification builds on **ARNS-CORE-1** by adding the management capabilities required for ongoing name administration. AR.IO Names require updates over time -- pointing records at new content, delegating control to collaborators, and managing network-level name operations. This specification standardizes these operations so that ANT owners have a consistent interface for record and controller management across the AR.IO ecosystem.
 
 ## Specification
 
 ### Overview
 
-The **ARNS-MANAGE-1** Specification includes the following requirements:
+The **ARNS-MANAGE-1** specification requires the following capabilities:
 
-- Must include a list of `Controllers` who act as secondary users who control the `Records` set in this ANT.
-- Must have an `Add-Controller` handler to add new `Controllers`.
-  - Authorized for the Process `Owner` only.
-- Must have a `Remove-Controller` handler to remove `Controllers`.
-  - Authorized for the Process `Owner` only.
-- Must have a `Set-Record` handler to set new `Records` and modify existing ones.
-  - Authorized for the Process `Owner`, `Controllers`, and individual record owners (for their own records).
-  - Supports optional `Priority` parameter for undername sorting.
-  - Supports optional record ownership and metadata fields: `Record-Owner`, `Display-Name`, `Logo`, `Description`, and `Keywords`.
-  - Priority and explicit owner assignment require ANT owner or controller authorization.
-- Must have a `Transfer-Record` handler to transfer ownership of a specific undername.
-  - Authorized for the Process `Owner`, `Controllers`, and the current record owner.
-- Must have a `Remove-Record` handler to remove `Records`.
-  - Authorized for the Process `Owner` and `Controllers`.
-- Must have a handler to read all `Controllers`.
-- Handler to read entire ANT `State` is updated to also return `Controllers`.
-- Must have AR.IO Network integration handlers:
-  - Authorized for the Process `Owner` only.
-    - `Release-Name` to release an ArNS name back to the registry.
-    - `Reassign-Name` to transfer an ArNS name to another ANT.
-  - Authorized for the Process `Owner` or the undername owner if the undername has one.
-    - `Approve-Primary-Name` to approve primary name requests.
-    - `Remove-Primary-Names` to remove primary name associations.
-  
+**Controller Management:**
 
-This adds flexibility for Arweave Name Process Owners to manage their records, leverage controllers for access controls, delegate undername ownership, and interact with the AR.IO Network for name management.
+- Must maintain a list of `Controllers` -- addresses authorized to manage records on behalf of the NFT holder.
+- Must have an `add_controller` instruction to add new controllers.
+  - Authorized for the NFT holder or existing controllers only.
+  - Maximum 10 controllers per ANT.
+- Must have a `remove_controller` instruction to remove controllers.
+  - Authorized for the NFT holder or existing controllers only.
+- Controllers must be automatically cleared when the NFT is transferred to a new holder (lazy reconciliation).
+
+**Record Management:**
+
+- Must have a `set_record` instruction to create new records and update existing ones.
+  - New records: authorized for the NFT holder and controllers only.
+  - Existing records: authorized for the NFT holder, controllers, or the record's delegated owner.
+  - Supports `target` (content address), `target_protocol` (storage protocol identifier), `ttl_seconds`, `priority`, and optional metadata fields.
+  - Supports optional per-record owner delegation.
+- Must have a `remove_record` instruction to remove records.
+  - Authorized for the NFT holder and controllers only.
+  - The root `@` record cannot be removed.
+- Must have a `transfer_record` instruction to transfer delegated ownership of a record.
+  - Authorized for the NFT holder, controllers, or the current record owner.
+
+**Read Operations:**
+
+- Must support reading the controller list.
+- The State read operation (from ARNS-CORE-1) is extended to include the controller list.
+
+**AR.IO Network Integration:**
+
+The following operations interact with the AR.IO Network programs (ario-arns and ario-core), not the ANT program itself. Authorization for name-owner operations is by the stored `owner` field on the relevant on-chain record (set at name purchase or record delegation), not by current Metaplex Core NFT possession -- see [Registry-Side Authorization](#registry-side-authorization) below.
+
+- `release_name` -- releases an ArNS name back to the registry (on ario-arns program).
+- `reassign_name` -- reassigns an ArNS name to a different ANT (on ario-arns program).
+- `request_primary_name` -- requests that an ArNS name become the caller's primary identity (on ario-core program).
+- `approve_primary_name` -- approves a pending primary name request (on ario-core program).
+- `remove_primary_name` -- the bound wallet removes its own primary-name binding (on ario-core program).
+- `remove_primary_name_for_base_name` -- the name owner revokes a primary-name binding using their name (on ario-core program).
+
+### Ownership Model
+
+Ownership of an ANT is determined solely by who holds the Metaplex Core NFT. There is no stored owner field that can be set independently of NFT possession.
+
+**Lazy ownership reconciliation:** The `AntConfig` account stores a `last_known_owner` field. On every write operation, the program reads the current NFT holder from the Metaplex Core asset account. If the holder differs from `last_known_owner`, the controller list is cleared and `last_known_owner` is updated. This ensures that transferring the NFT via any Metaplex-compatible marketplace or wallet automatically revokes all controller access without requiring a separate transaction.
+
+A permissionless `reconcile` instruction is also available to explicitly trigger reconciliation (e.g., immediately after a marketplace transfer) without performing any other operation.
 
 ### Objects
 
-The **ARNS-MANAGE-1** specification includes all of the objects contained in **ARNS-CORE-1**.
+The **ARNS-MANAGE-1** specification includes all objects from **ARNS-CORE-1**, plus the following:
 
-#### ARNS-MANAGE-1 Objects
+#### AntControllers
 
-```
--- ARNS-MANAGE-1 Objects
-Owner = Owner or ao.env.Process.Owner
-Controllers = Controllers or { Owner }
-Initialized = Initialized or false
+Stores the controller list for an ANT. Derived as a PDA with seeds `["ant_controllers", mint]`.
 
--- ARNS-CORE-1 Objects
-Records = Records or {
-  ["@"] = {
-    transactionId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
-    ttlSeconds = 3600,
-    priority = 0,
-    -- Optional ownership and metadata fields
-    owner = nil,         -- Record owner address (optional)
-    displayName = nil,   -- Display name (max 61 chars, optional)
-    logo = nil,          -- Arweave TX ID for logo (optional)
-    description = nil,   -- Description (max 512 chars, optional)
-    keywords = nil       -- Array of keywords; up to 16, each max 32 chars (optional)
-  }
-}
-```
+| Field       | Type      | Description                                        |
+| ----------- | --------- | -------------------------------------------------- |
+| mint        | PublicKey | The Metaplex Core asset (NFT mint) this belongs to |
+| controllers | PublicKey[] | Controller addresses (max 10)                    |
+| bump        | u8        | PDA bump seed                                      |
 
-### Handlers
+#### AntRecord (extended from ARNS-CORE-1)
 
-#### Action Map
+Each undername record is stored as two PDAs: a required `AntRecord` (resolution-critical fields) and an optional `AntRecordMetadata` (descriptive fields). The metadata account is created lazily when an optional field is first written.
 
-The following actions are handled in the **ARNS-MANAGE-1** specification and include the actions contained in **ARNS-CORE-1**.
+PDA seeds: `["ant_record", mint, hash(undername.lowercase())]`
 
-```
-ARNSCoreSpecActionMap = {
-  -- read actions
-  Record = "Record",
-  Records = "Records",
-  State = "State",
-}
+| Field                 | Type            | Description                                                              |
+| --------------------- | --------------- | ------------------------------------------------------------------------ |
+| mint                  | PublicKey       | The Metaplex Core asset this record belongs to                           |
+| undername             | String          | The undername (e.g. `@`, `blog`, `docs`) -- lowercase, max 61 chars      |
+| target                | String          | Content address -- Arweave TX ID (43 chars), IPFS CID, or future protocol. Max 128 chars |
+| target_protocol       | u8              | Storage protocol: `0` = Arweave (default), `1` = IPFS.                                  |
+| ttl_seconds           | u32             | Cache TTL in seconds (60 -- 86400)                                        |
+| priority              | Option\<u32\>   | Sort priority for undername resolution. Must be `0` (or unset) for `@`. Non-`@` records accept any non-negative value. Unset records sort lexicographically |
+| owner                 | Option\<PublicKey\> | Delegated record owner. When set, this address can update content fields (target, ttl, metadata) but cannot change priority or record ownership |
+| last_reconciled_owner | PublicKey       | ANT owner at last record modification -- used to detect stale record owners after NFT transfer |
+| bump                  | u8              | PDA bump seed                                                            |
+| version               | u8              | Schema version for per-record migrations                                 |
 
-ARNSManageSpecActionMap = {
-  -- read actions
-  Controllers = "Controllers",
-  -- write actions
-  AddController = "Add-Controller",
-  RemoveController = "Remove-Controller",
-  SetRecord = "Set-Record",
-  TransferRecord = "Transfer-Record"
-  RemoveRecord = "Remove-Record",
-  -- AR.IO Network integration
-  ReleaseName = "Release-Name",
-  ReassignName = "Reassign-Name",
-  ApprovePrimaryName = "Approve-Primary-Name",
-  RemovePrimaryNames = "Remove-Primary-Names",
-}
-```
+#### AntRecordMetadata
 
-#### Controllers
+PDA seeds: `["ant_record_meta", mint, hash(undername.lowercase())]`
 
-Gets the entire `Controllers` table, including each wallet that has controller permission on this process.
+| Field              | Type                | Description                                            |
+| ------------------ | ------------------- | ------------------------------------------------------ |
+| mint               | PublicKey           | The Metaplex Core asset this metadata belongs to       |
+| display_name       | Option\<String\>    | Optional display name (max 61 chars)                   |
+| record_logo        | Option\<String\>    | Optional logo (Arweave TX ID, 43 chars)                |
+| record_description | Option\<String\>    | Optional description (max 256 chars)                   |
+| record_keywords    | Option\<String[]\>  | Optional keywords (max 8, each max 32 chars)           |
+| bump               | u8                  | PDA bump seed                                          |
+| version            | u8                  | Schema version for per-record-metadata migrations      |
 
-Executable by anonymous users.
+### Instructions
 
-##### Parameters
+#### Instruction Summary
 
-No parameters needed.
+The following instructions are defined by the **ARNS-MANAGE-1** specification, in addition to the read instructions from **ARNS-CORE-1**.
 
-##### Rules
+| Instruction               | Program    | Authorization                          |
+| ------------------------- | ---------- | -------------------------------------- |
+| `add_controller`          | ario-ant   | NFT holder or controller               |
+| `remove_controller`       | ario-ant   | NFT holder or controller               |
+| `set_record`              | ario-ant   | NFT holder, controller, or record owner (limited) |
+| `remove_record`           | ario-ant   | NFT holder or controller               |
+| `transfer_record`         | ario-ant   | NFT holder, controller, or record owner |
+| `reconcile`               | ario-ant   | Permissionless                         |
+| `release_name`            | ario-arns  | `ArnsRecord.owner`                     |
+| `reassign_name`           | ario-arns  | `ArnsRecord.owner`                     |
+| `request_primary_name`    | ario-core  | Requestor (signs and pays the fee)     |
+| `approve_primary_name`    | ario-core  | `AntRecord.owner` (requested undername)|
+| `remove_primary_name`     | ario-core  | Owner of the primary-name binding      |
+| `remove_primary_name_for_base_name` | ario-core | `AntRecord.owner` (`@` undername) |
 
-- Must return entire `Controllers` object as JSON in the data field of the response notice.
-- Must add `X-`forwarded tags to the response notice.
+---
 
-##### Action
+#### add_controller
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Controllers"
-})
-```
+Adds an address to the controller list, granting it permission to manage records for this ANT.
 
-##### Responses
-
-**Valid `Controllers`**
-
-```
-{
-  Target = msg.From,
-  Action = "Controllers-Notice",
-  Data = json.encode(Controllers),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Add-Controller
-
-Adds a new controller into the `Controllers` table, giving them access to modify the Arweave Name's `Records`.
-
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+**Authorization:** NFT holder or existing controller.
 
 ##### Parameters
 
-| Name       | Type   | Description                                                                                            |
-| ---------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| Controller | string | The controller being added to the Controllers table, e.g., iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA |
+| Name       | Type      | Description                                  |
+| ---------- | --------- | -------------------------------------------- |
+| controller | PublicKey | The address to add as a controller           |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Controller` parameter (string) as a message tag.
-- The `Controller` must not already exist in the `Controllers` table.
-- Must add `X-`forwarded tags to the response notice.
+- Caller must be the NFT holder or an existing controller (after lazy reconciliation).
+- The `controller` address must not already exist in the controller list.
+- The controller list must not exceed 10 entries.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Add-Controller",
-  Controller = "{Wallet Address}"
-})
-```
+| Error                    | Condition                                  |
+| ------------------------ | ------------------------------------------ |
+| Unauthorized             | Caller is not the NFT holder or controller |
+| ControllerAlreadyExists  | Address is already a controller            |
+| MaxControllersReached    | Controller list already has 10 entries     |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### remove_controller
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Add-Controller-Notice",
-  Error = "Add-Controller-Error",
-  ["Message-Id"] = msg.Id,
-  Data = permissionErr
-}
-```
+Removes an address from the controller list.
 
-**Invalid `Controller`**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Add-Controller-Notice",
-  Error = "Add-Controller-Error",
-  ["Message-Id"] = msg.Id,
-  Data = controllerRes
-}
-```
-
-**Valid `Controller`**
-
-```
-{
-  Target = msg.From,
-  Action = "Add-Controller-Notice",
-  Data = json.encode(Controllers),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Remove-Controller
-
-Removes an existing controller in the `Controllers` table, removing their access to modify the Arweave Name's `Records.
-
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+**Authorization:** NFT holder or existing controller.
 
 ##### Parameters
 
-| Name       | Type   | Description                                                                                                           |
-| ---------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
-| Controller | string | The controller wallet address to remove from the Controllers table, e.g., iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA |
+| Name       | Type      | Description                                  |
+| ---------- | --------- | -------------------------------------------- |
+| controller | PublicKey | The controller address to remove             |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Controller` parameter (string) as a message tag.
-- The `Controller` must already exist in the `Controllers` table.
-- Must add `X-`forwarded tags to the response notice.
+- Caller must be the NFT holder or an existing controller (after lazy reconciliation).
+- The `controller` address must exist in the controller list.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Remove-Controller",
-  Controller = "{Wallet Address}"
-})
-```
+| Error              | Condition                                  |
+| ------------------ | ------------------------------------------ |
+| Unauthorized       | Caller is not the NFT holder or controller |
+| ControllerNotFound | Address is not in the controller list      |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### set_record
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Remove-Controller-Notice",
-  Error = "Remove-Controller-Error",
-  ["Message-Id"] = msg.Id,
-  Data = permissionErr,
-}
-```
+Creates a new undername record or updates an existing one. This is the primary instruction for managing what content an AR.IO Name points to.
 
-**Invalid `Controller`**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Remove-Controller-Notice",
-  Error = "Remove-Controller-Error",
-  ["Message-Id"] = msg.Id,
-  Data = removeRes,
-}
-```
-
-**Valid `Controller`**
-
-```
-{
-  Target = msg.From,
-  Action = "Remove-Controller-Notice",
-  Data = json.encode(Controllers),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Set-Record
-
-Updates an existing undername's Sub-Domain in the Records table, including modifying the transaction id, time to live, ownership, and optional metadata.
-
-Executable by the process Owner, an authorized user in the Controllers table, or the record owner (for their own record).
+**Authorization:**
+- Creating a new record: NFT holder or controller only.
+- Updating an existing record: NFT holder, controller, or the record's delegated owner.
+- Record owners can update `target`, `ttl_seconds`, and metadata fields, but cannot change `priority` or `record_owner`.
 
 ##### Parameters
 
-| Name                   | Type   | Description                                                                                 |
-| ---------------------- | ------ | ------------------------------------------------------------------------------------------- |
-| Sub-Domain             | string | The undername record to update, e.g., `@`, `ardrive`, or `dapp_ardrive`                     |
-| Transaction-Id         | string | The Arweave transaction ID that this undername points to.                                   |
-| TTL-Seconds            | string | The time to live for this record, indicating how long an ArNS Resolver should cache it for. |
-| Priority               | string | Optional. The priority for ArNS resolution of undernames. Must be integer > 0 (or 0 for `@`). Only settable by ANT owner/controllers. |
-| Record-Owner           | string | Optional. The address to assign as the owner of this record. Only settable by ANT owner/controllers. |
-| Display-Name           | string | Optional. A display name for this undername (max 61 characters). |
-| Logo                   | string | Optional. An Arweave transaction ID for the logo image. |
-| Description            | string | Optional. A description of this undername (max 512 characters). |
-| Keywords               | string | Optional. A JSON-encoded array of keywords (max 16 keywords, each max 32 characters). |
-| Allow-Unsafe-Addresses | string | Optional. If set to `true`, allows setting addresses that may not be valid AO addresses.    |
+| Name               | Type              | Description                                                                                   |
+| ------------------ | ----------------- | --------------------------------------------------------------------------------------------- |
+| undername           | String            | The undername to set (e.g. `@`, `blog`, `dapp_ardrive`). Lowercased before storage. Max 61 chars. Must start with alphanumeric (or be exactly `@`) |
+| target              | String            | Content address. For Arweave (protocol 0): a 43-character base64url TX ID. For IPFS (protocol 1): a CIDv0 (`Qm...`, 46 chars) or CIDv1 (multibase-prefixed) string. Max 128 chars. |
+| target_protocol     | u8                | Storage protocol: `0` = Arweave, `1` = IPFS, `2+` = reserved for future protocols.           |
+| ttl_seconds         | u32               | Cache TTL in seconds. Must be between 60 and 86400 (1 minute to 1 day)                       |
+| priority            | Option\<u32\>     | Optional sort priority. For `@` records, must be `0` or unset. Only NFT holder / controllers can set this |
+| record_owner        | Option\<PublicKey\> | Optional delegated owner address. Only NFT holder / controllers can set or clear this         |
+| display_name        | Option\<String\>  | Optional display name for this record (max 61 chars)                                          |
+| record_logo         | Option\<String\>  | Optional logo (Arweave TX ID, 43 chars)                                                       |
+| record_description  | Option\<String\>  | Optional description (max 256 chars)                                                          |
+| record_keywords     | Option\<String[]\> | Optional keywords (max 8 keywords, each max 32 chars, no duplicates)                          |
 
 ##### Rules
 
-- Must be an authorized process `Owner`, `Controller`, or the record owner (for existing records they own).
-- New records can only be created by the ANT owner or controllers.
-- Must specify a valid `Sub-Domain` parameter (string) as a message tag.
-- Must specify a valid `Transaction-Id` parameter (string) as a message tag.
-- Must specify a valid `TTL-Seconds` parameter (string) as a message tag, which is an integer between 60 and 86400.
-- `Priority` and `Record-Owner` assignment require ANT owner or controller authorization.
-- `Priority` must be an integer greater than 0 for undernames, or exactly 0 for the `@` record.
-- `Display-Name` must not exceed 61 characters.
-- `Description` must not exceed 512 characters.
-- `Keywords` must be a valid JSON array with up to 16 keywords, each consisting of alphanumeric characters, dashes, underscores, @ or #, and not exceeding 32 characters.
-- Must add `X-`forwarded tags to the response notice.
+- Caller must be authorized (see Authorization above).
+- `undername` must be a valid format: `@`, or starting with an alphanumeric character followed by alphanumeric, dash, or underscore characters.
+- `target` must be a valid content address for the declared `target_protocol` (Arweave: 43 base64url characters; IPFS: CIDv0 `Qm`-prefixed 46-char string OR CIDv1 multibase-prefixed string).
+- `ttl_seconds` must be in range [60, 86400].
+- For `@` records, `priority` must be `0` or unset (it always resolves to `0`).
+- For non-`@` records, if `priority` is provided, the caller must be the NFT holder or a controller.
+- Only the NFT holder or a controller can assign or clear `record_owner`.
+- On NFT transfer (detected via `last_reconciled_owner` mismatch), the record's `owner` field is automatically cleared before permission checks.
+- Keywords must be unique, alphanumeric with dash, underscore, `#`, and `@` allowed, no spaces.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Set-Record",
-  ["Sub-Domain"] = "foo",
-  ["Transaction-Id"] = "{Base64 URL}",
-  ["TTL-Seconds"] = "900",
-  Priority = "10", -- optional, ANT owner/controllers only
-  ["Record-Owner"] = "{Wallet Address}", -- optional, ANT owner/controllers only
-  ["Display-Name"] = "Foo's Site", -- optional
-  Logo = "Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A", -- optional
-  Description = "This is Foo's personal site", -- optional
-  Keywords = '["personal","blog"]' -- optional, JSON array
-})
-```
+| Error                              | Condition                                                    |
+| ---------------------------------- | ------------------------------------------------------------ |
+| InvalidUndername                   | Undername format is invalid                                  |
+| InvalidTarget                      | Content target is not valid for the declared protocol        |
+| InvalidTtl                         | TTL is outside [60, 86400] range                             |
+| CannotChangePriorityOfRoot         | Attempted to set non-zero priority on `@` record             |
+| PriorityRequiresOwnerOrController  | Record owner tried to change priority                        |
+| OnlyOwnerOrControllerCanCreate     | Record owner or unauthorized user tried to create new record |
+| UnauthorizedRecordAccess           | Caller has no permission for this record                     |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### remove_record
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Record-Notice",
-  Data = permissionErr,
-  Error = "Set-Record-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+Removes an undername record, closing its PDA account and returning rent to the caller.
 
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Record-Notice",
-  Data = setRecordResult,
-  Error = "Set-Record-Error",
-  ["Message-Id"] = msg.Id,
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Set-Record-Notice",
-  Data = json.encode({
-    transactionId = transactionId,
-    ttlSeconds = ttlSeconds,
-    priority = priority,
-    owner = owner, -- if set
-    displayName = displayName, -- if set
-    logo = logo, -- if set
-    description = description, -- if set
-    keywords = keywords, -- if set
-  }),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Transfer-Record
-
-Transfers ownership of a specific undername record to another address.
-
-Executable by the process `Owner`, an authorized user in the `Controllers` table, or the current record owner.
+**Authorization:** NFT holder or controller only.
 
 ##### Parameters
 
-| Name                   | Type   | Description                                                                                                   |
-| ---------------------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| Sub-Domain             | string | The undername record to transfer, e.g., `@`, `ardrive`, or `dapp_ardrive`                                     |
-| Recipient              | string | The wallet address to transfer record ownership to, e.g., iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA         |
-| Allow-Unsafe-Addresses | string | Optional. If set to `true`, allows transferring to addresses that may not be valid AO addresses.              |
+No instruction parameters. The record to remove is identified by the PDA derivation (the record account is passed as part of the account context).
 
 ##### Rules
 
-- Must be an authorized process `Owner`, `Controller`, or the current record owner.
-- Must specify a valid `Sub-Domain` parameter (string) as a message tag.
-- Must specify a valid `Recipient` parameter (string) as a message tag.
-- The undername's `Sub-Domain` must already exist in the `Records` table.
-- The record must have an existing owner to be transferable.
-- Must add `X-`forwarded tags to the response notice.
-- Sends an additional `Transfer-Record-Notice` to the new owner.
+- Caller must be the NFT holder or a controller (after lazy reconciliation).
+- The `@` (root) record cannot be removed.
+- The record PDA account is closed and rent is returned to the caller.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Transfer-Record",
-  ["Sub-Domain"] = "foo",
-  Recipient = "{Wallet Address}"
-})
-```
+| Error                  | Condition                                  |
+| ---------------------- | ------------------------------------------ |
+| Unauthorized           | Caller is not the NFT holder or controller |
+| CannotRemoveRootRecord | Attempted to remove the `@` record         |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### transfer_record
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Transfer-Record-Notice",
-  Data = permissionErr,
-  Error = "Transfer-Record-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+Transfers delegated ownership of a record to a new address. This changes who the `record_owner` is without modifying the record's content.
 
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Transfer-Record-Notice",
-  Data = transferRecordResult,
-  Error = "Transfer-Record-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Valid parameters**
-
-```
--- Notice sent to the caller
-{
-  Target = msg.From,
-  Action = "Transfer-Record-Notice",
-  Data = json.encode({
-    ["Sub-Domain"] = subdomain,
-    Recipient = recipient,
-    ["Previous-Owner"] = previousOwner,
-  }),
-  ... other forwarded tag name and value pairs
-}
-
--- Additional notice sent to the new owner
-{
-  Target = recipient,
-  Action = "Transfer-Record-Notice",
-  ["Sub-Domain"] = subdomain,
-  ["Previous-Owner"] = previousOwner,
-  Data = json.encode({
-    ["Sub-Domain"] = subdomain,
-    Recipient = recipient,
-    ["Previous-Owner"] = previousOwner,
-  })
-}
-```
-
-#### Remove-Record
-
-Removes an existing undername’s `Sub-Domain` in the Records table.
+**Authorization:** NFT holder, controller, or the current record owner.
 
 ##### Parameters
 
-| Name       | Type   | Description                                                             |
-| ---------- | ------ | ----------------------------------------------------------------------- |
-| Sub-Domain | string | The undername record to remove, e.g., `@`, `ardrive`, or `dapp_ardrive` |
+| Name      | Type      | Description                                          |
+| --------- | --------- | ---------------------------------------------------- |
+| new_owner | PublicKey | The address to transfer record ownership to          |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Sub-Domain` parameter (string) as a message tag.
-- The undername’s `Sub-Domain` must already exist in the `Records` table.
-- Must add `X-`forwarded tags to the response notice.
+- If the caller is the NFT holder or a controller, they can assign record ownership to any address (even if the record currently has no owner).
+- If the caller is the current record owner (not the NFT holder or controller), they can transfer ownership to a different address.
+- Cannot transfer to the current record owner (no-op prevention).
+- On NFT transfer (detected via `last_reconciled_owner` mismatch), the record's `owner` field is automatically cleared before permission checks.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Remove-Record",
-  ["Sub-Domain"] = "foo"
-})
-```
+| Error                    | Condition                                                 |
+| ------------------------ | --------------------------------------------------------- |
+| Unauthorized             | Caller is not authorized                                  |
+| UnauthorizedRecordAccess | Caller is neither owner/controller nor record owner       |
+| RecordHasNoOwner         | Non-owner/controller caller tried to transfer unowned record |
+| RecordTransferToSelf     | `new_owner` is the same as the current record owner       |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### reconcile
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Remove-Record-Notice",
-  Data = permissionErr,
-  Error = "Remove-Record-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+Forces ownership reconciliation. If the NFT has been transferred, this clears all controllers and updates `last_known_owner`. This is useful to call immediately after a marketplace transfer to ensure clean state without waiting for the next write operation.
 
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Remove-Record-Notice",
-  Data = removeRecordResult,
-  Error = "Remove-Record-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Remove-Record-Notice",
-  Data = json.encode(Records),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### State
-
-The State handler is updated in **ARNS-MANAGE-1** to return specific information about the state of the process, including all `Records`, its current `Owner`, and all `Controllers`.
-
-Executable by anonymous users.
+**Authorization:** Permissionless -- anyone can trigger reconciliation.
 
 ##### Parameters
 
-No parameters necessary.
+No parameters.
 
 ##### Rules
 
-- Must return a state object as JSON in the data field of the response notice. The state object must include:
-  - Entire `Records` table.
-  - Entire `Controllers` table.
-  - Process `Owner`.
-- Must add `X-`forwarded tags to the response notice.
+- Reads the current NFT holder from the Metaplex Core asset account.
+- If the holder differs from `last_known_owner`, clears all controllers and updates `last_known_owner`.
+- If the holder matches, this is a no-op.
 
-##### Action
+---
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "State"
-})
-```
+### AR.IO Network Integration Instructions
 
-##### Responses
+The following instructions live on the `ario-arns` and `ario-core` programs, not on the ANT program. They are the primary way an ArNS name owner interacts with the AR.IO Name System at the network level.
 
-**Valid `State`**
+#### Registry-Side Authorization
 
-```
-{
-  Target = msg.From,
-  Action = "State-Notice",
-  Data = json.encode({
-    Records = Records,
-    Controllers = Controllers,
-    Owner = ao.env.Process.Owner,
-  }),
-  ... other forwarded tag name and value pairs
-}
-```
+Per ADR-016 / BD-100, `ario-arns` and `ario-core` are MPL-agnostic — they do **not** read the Metaplex Core asset account to verify authorization. Instead, each instruction below requires:
 
-### AR.IO Network Integration Handlers
+- **`release_name`, `reassign_name`** (`ario-arns`): caller must match `ArnsRecord.owner` (set at name purchase via `buy_name` / `buy_returned_name`).
+- **`approve_primary_name`, `remove_primary_name_for_base_name`** (`ario-core`): caller must match `AntRecord.owner` for the relevant undername, read from the program named in the asset's `ANT Program` Attributes-plugin entry (or the canonical `ARIO_ANT_PROGRAM_ID` when absent).
 
-The following handlers enable ANTs to interact with the AR.IO Network Process for managing ArNS name registrations.
+The ANT program (or any pluggable equivalent) is responsible for keeping the on-chain `owner` field in sync with the current NFT holder via the standard record-delegation flow. SDKs SHOULD ensure `owner` reflects the intended signer before invoking these instructions; an NFT transferred via a marketplace alone does **not** automatically convey registry-side authority.
 
-#### Release-Name
+---
 
-Releases an ArNS name back to the AR.IO Network, making it available for registration by others.
+#### release_name
 
-Executable by the process `Owner` only.
+Releases a permanently purchased (permabuy) ArNS name back to the AR.IO Network, making it available for re-registration after a return auction period.
+
+**Program:** ario-arns
+
+**Authorization:** `ArnsRecord.owner` (see [Registry-Side Authorization](#registry-side-authorization)).
 
 ##### Parameters
 
-| Name           | Type   | Description                                                      |
-| -------------- | ------ | ---------------------------------------------------------------- |
-| IO-Process-Id  | string | The AR.IO Network Process ID to send the release request to.    |
-| Name           | string | The ArNS name to release, e.g., `ardrive` or `my-name`.         |
+No instruction-level parameters. The ArNS record is passed as part of the account context.
 
 ##### Rules
 
-- Must be the process `Owner`.
-- Must specify a valid `IO-Process-Id` parameter (Arweave address) as a message tag.
-- Must specify a valid `Name` parameter (string) as a message tag.
-- Sends a message to the AR.IO Network Process to release the name.
-- Must add `X-`forwarded tags to the response notice.
+- Caller must match `ArnsRecord.owner`.
+- Only permabuy names can be released (leased names expire naturally).
+- The name must be currently active (not expired).
+- Creates a `ReturnedName` entry and removes the name from the on-chain `NameRegistry`.
+- The ArNS record account is closed.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Release-Name",
-  ["IO-Process-Id"] = "{AR.IO Network Process ID}",
-  Name = "my-arns-name"
-})
-```
+| Error             | Condition                                       |
+| ----------------- | ----------------------------------------------- |
+| NotAntHolder      | Caller does not match `ArnsRecord.owner`        |
+| CannotReleaseLease| Name is a lease, not a permabuy                 |
+| RecordExpired     | Name has already expired                        |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### reassign_name
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Release-Name-Notice",
-  Data = "Caller is not the process owner",
-  Error = "Release-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+Reassigns an ArNS name from its current ANT to a different ANT. The name registration (lease or permabuy) stays intact; only the ANT association changes.
 
-**Invalid parameters**
+**Program:** ario-arns
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Release-Name-Notice",
-  Data = "Invalid Arweave ID",
-  Error = "Release-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Release-Name-Notice",
-  Initiator = msg.From,
-  Name = name,
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Reassign-Name
-
-Reassigns an ArNS name from this ANT to another ANT Process.
-
-Executable by the process `Owner` only.
+**Authorization:** `ArnsRecord.owner` (see [Registry-Side Authorization](#registry-side-authorization)).
 
 ##### Parameters
 
-| Name           | Type   | Description                                                      |
-| -------------- | ------ | ---------------------------------------------------------------- |
-| IO-Process-Id  | string | The AR.IO Network Process ID to send the reassign request to.   |
-| Process-Id     | string | The new ANT Process ID to assign the name to.                   |
-| Name           | string | The ArNS name to reassign, e.g., `ardrive` or `my-name`.        |
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| new_ant | PublicKey | The Metaplex Core asset (mint) of the new ANT to assign the name to |
 
 ##### Rules
 
-- Must be the process `Owner`.
-- Must specify a valid `IO-Process-Id` parameter (Arweave address) as a message tag.
-- Must specify a valid `Process-Id` parameter (Arweave address) as a message tag.
-- Must specify a valid `Name` parameter (string) as a message tag.
-- Sends a message to the AR.IO Network Process to reassign the name.
-- Must add `X-`forwarded tags to the response notice.
+- Caller must match `ArnsRecord.owner`.
+- The name must be currently active (not expired or in grace period).
+- `new_ant` is stored without on-chain validation. Callers SHOULD verify it is a valid Metaplex Core asset client-side; subsequent ANT-side instructions will reject mismatches.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Reassign-Name",
-  ["IO-Process-Id"] = "{AR.IO Network Process ID}",
-  ["Process-Id"] = "{New ANT Process ID}",
-  Name = "my-arns-name"
-})
-```
+| Error         | Condition                                       |
+| ------------- | ----------------------------------------------- |
+| NotAntHolder  | Caller does not match `ArnsRecord.owner`        |
+| RecordExpired | Name has expired                                |
+| InGracePeriod | Name is in its grace period                     |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### Primary Names
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Reassign-Name-Notice",
-  Data = "Caller is not the process owner",
-  Error = "Reassign-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+A **primary name** is a wallet's display identity within the AR.IO ecosystem — when wallet `W` sets `ardrive_alice` as its primary, gateways and apps can render `W` as that name. The binding is two-way (forward + reverse lookup) and requires consent from both the requesting wallet and the name owner.
 
-**Invalid parameters**
+Flow:
+
+1. **Request** — Wallet `W` calls `request_primary_name(name)` on `ario-core`, paying a fee. A `PrimaryNameRequest` PDA is created with a 7-day expiry.
+2. **Approve** — The name owner (the `AntRecord.owner` for the relevant undername) calls `approve_primary_name`, consuming the request. This creates `PrimaryName` (forward: wallet → name) and `PrimaryNameReverse` (reverse: name → wallet) PDAs.
+3. **Remove** — Either `W` (via `remove_primary_name`) or the name owner (via `remove_primary_name_for_base_name`) can dissolve the binding at any time. Both `PrimaryName` and `PrimaryNameReverse` accounts are closed.
+
+PDA seeds (under `ario-core`):
 
 ```
-{
-  Target = msg.From,
-  Action = "Invalid-Reassign-Name-Notice",
-  Data = "Invalid Arweave ID",
-  Error = "Reassign-Name-Error",
-  ["Message-Id"] = msg.Id
-}
+PrimaryNameRequest  seeds = ["primary_name_request", requestor_pubkey]
+PrimaryName         seeds = ["primary_name",          owner_pubkey]
+PrimaryNameReverse  seeds = ["primary_name_reverse",  sha256(name.toLowerCase())]
 ```
 
-**Valid parameters**
+A `PrimaryNameRequest` older than the configured expiry (default 7 days) is closed permissionlessly by `close_expired_primary_name_request`. Approving an expired request fails with `PrimaryNameRequestExpired`.
 
-```
-{
-  Target = msg.From,
-  Action = "Reassign-Name-Notice",
-  Initiator = msg.From,
-  Name = name,
-  ["Process-Id"] = antProcessIdToReassign,
-  ... other forwarded tag name and value pairs
-}
-```
+---
 
-#### Approve-Primary-Name
+#### request_primary_name
 
-Approves a primary name request for a specific recipient address.
+Initiates a primary name request. The requestor (a normal user wallet) wishes to bind a name to their address; the name owner must subsequently approve.
 
-Executable by the process `Owner`, or the record owner (for their own undername).
+**Program:** ario-core
+
+**Authorization:** Any wallet may request (signs the transaction and pays the fee).
 
 ##### Parameters
 
-| Name                   | Type   | Description                                                      |
-| ---------------------- | ------ | ---------------------------------------------------------------- |
-| IO-Process-Id          | string | The AR.IO Network Process ID to send the approval to.           |
-| Recipient              | string | The address to approve for primary name usage.                  |
-| Name                   | string | The ArNS name or undername to approve, e.g., `ardrive`, `my-name`, or `alice`. |
-| Allow-Unsafe-Addresses | string | Optional. If set to `true`, allows addresses that may not be valid AO addresses. |
+| Name | Type   | Description                                       |
+| ---- | ------ | ------------------------------------------------- |
+| name | String | The ArNS name being requested (no undername; the binding is for `<wallet> → name`). |
 
 ##### Rules
 
-- Must be the process `Owner`, or the record owner of the specified undername.
-- If the caller is a record owner (not ANT owner), the `Recipient` must equal the caller's address (record owners can only approve primary names for themselves).
-- Must specify a valid `IO-Process-Id` parameter (Arweave address) as a message tag.
-- Must specify a valid `Recipient` parameter (AO address) as a message tag.
-- Must specify a valid `Name` parameter (string) as a message tag.
-- Sends a message to the AR.IO Network Process to approve the primary name request.
+- The ArNS name must exist in the registry and be active (lease not expired).
+- The fee (`PRIMARY_NAME_REQUEST_BASE_FEE`, ~0.2 ARIO at genesis) is charged in ARIO tokens.
+- Any existing `PrimaryNameRequest` for the requestor is overwritten.
+- Creates a `PrimaryNameRequest` with `expires_at = now + 7 days` (default).
 
-##### Action
+---
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Approve-Primary-Name",
-  ["IO-Process-Id"] = "{AR.IO Network Process ID}",
-  Recipient = "{Address to approve}",
-  Name = "alice" -- can be base name or undername
-})
-```
+#### approve_primary_name
 
-##### Responses
+Approves a pending primary name request. When a user requests to use an ArNS name as their primary name, the name owner must approve the request.
 
-**Permission error, not authorized**
+**Program:** ario-core
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Approve-Primary-Name-Notice",
-  Data = "Caller is not the process owner",
-  Error = "Approve-Primary-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Approve-Primary-Name-Notice",
-  Data = "Invalid Arweave ID",
-  Error = "Approve-Primary-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-#### Remove-Primary-Names
-
-Removes one or more primary name associations.
-
-Executable by the process `Owner`, or record owners (for their own undernames).
+**Authorization:** `AntRecord.owner` for the requested undername (see [Registry-Side Authorization](#registry-side-authorization)).
 
 ##### Parameters
 
-| Name           | Type   | Description                                                      |
-| -------------- | ------ | ---------------------------------------------------------------- |
-| IO-Process-Id  | string | The AR.IO Network Process ID to send the removal request to.    |
-| Names          | string | Comma-separated list of names to remove primary status from.    |
+| Name                | Type     | Description                                         |
+| ------------------- | -------- | --------------------------------------------------- |
+| reverse_lookup_hash | [u8; 32] | Hash of the name (for reverse lookup PDA derivation) |
 
 ##### Rules
 
-- Must be the process `Owner`, or the record owner for each name being removed.
-- If the caller is a record owner (not ANT owner), they can only remove their own record's primary name status.
-- Must specify a valid `IO-Process-Id` parameter (Arweave address) as a message tag.
-- Must specify a valid `Names` parameter (comma-separated string) as a message tag.
-- Each name in the list must be a valid undername format.
-- Each name is validated to ensure the caller has permission (either ANT owner or the specific record owner).
-- Sends a message to the AR.IO Network Process to remove primary name associations.
+- Caller must match the `owner` field of the relevant `AntRecord`, read from the program named in the asset's `ANT Program` Attributes-plugin entry (or `ARIO_ANT_PROGRAM_ID` when absent).
+- The primary name request must not be expired.
+- The ArNS record (passed via `remaining_accounts`) must exist and be active (lease not expired).
+- If the requestor already has a different primary name set, they must remove it first.
+- Creates or updates the `PrimaryName` and `PrimaryNameReverse` accounts.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Remove-Primary-Names",
-  ["IO-Process-Id"] = "{AR.IO Network Process ID}",
-  Names = "name1,name2,name3"
-})
-```
+| Error                          | Condition                                              |
+| ------------------------------ | ------------------------------------------------------ |
+| NotAntHolder                   | Caller does not match `AntRecord.owner`                |
+| PrimaryNameRequestExpired      | The request has expired                                |
+| MustRemoveExistingPrimaryName  | Requestor already has a different primary name          |
+| PrimaryNameAlreadySet          | Another user already has this name as their primary     |
 
-##### Responses
+---
 
-**Permission error, not authorized**
+#### remove_primary_name
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Remove-Primary-Names-Notice",
-  Data = "Caller is not the process owner",
-  Error = "Remove-Primary-Names-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+Removes the caller's own primary-name binding. Self-service equivalent of `remove_primary_name_for_base_name`.
 
-**Invalid parameters**
+**Program:** ario-core
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Remove-Primary-Names-Notice",
-  Data = "Invalid Arweave ID",
-  Error = "Remove-Primary-Names-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+**Authorization:** The wallet that owns the `PrimaryName` binding (i.e., the wallet whose name is being unset).
 
-### Boot Handler
+##### Parameters
 
-The ANT process includes a special `_boot` handler that is triggered when the process is initialized or loaded. This handler is particularly important for WASM module implementations.
+No parameters. The binding to remove is identified by the caller's pubkey via PDA derivation.
 
-#### Behavior
+##### Rules
 
-When the process receives a boot message (Type = "Process" from the Owner):
+- Closes the caller's `PrimaryName` and the corresponding `PrimaryNameReverse` PDA.
 
-1. **State Initialization**: If the message includes Data containing a valid JSON state, the ANT will initialize its state from this data, setting:
-   - Records
-   - Controllers
-   - Owner
-   - Name, Ticker, Logo, Description, Keywords (if ARNS-TOKEN-1 is implemented)
-   - Balances (if ARNS-TOKEN-1 is implemented)
+---
 
-2. **Credit Notice**: Sends a Credit-Notice to the Owner (if ARNS-TOKEN-1 is implemented).
+#### remove_primary_name_for_base_name
 
-3. **State Notification**: 
-   - Sends a State-Notice to the ANT Registry (if configured with ANT-Registry-Id tag).
-   - Sends a patch notice for state caching.
-   - Sends a self State-Notice to enable caching.
+Removes a primary name association for a base ArNS name. This allows the name owner to revoke a user's primary name that was set using their ArNS name.
 
-4. **Initialized Flag**: Sets the `Initialized` flag to true after successful initialization.
+**Program:** ario-core
 
-#### Rules
+**Authorization:** `AntRecord.owner` for the `@` undername (see [Registry-Side Authorization](#registry-side-authorization)).
 
-- Only the process Owner can trigger the boot handler.
-- Invalid JSON data will result in an Invalid-Boot-Notice error.
-- The boot handler has highest priority (prepended to handler list).
-- This handler is automatically configured and should not be modified.
+##### Parameters
+
+| Name                | Type     | Description                                         |
+| ------------------- | -------- | --------------------------------------------------- |
+| reverse_lookup_hash | [u8; 32] | Hash of the name (for reverse lookup PDA derivation) |
+
+##### Rules
+
+- Caller must match the `owner` field of the base name's `AntRecord` (`@` undername), read from the asset's declared ANT program (or `ARIO_ANT_PROGRAM_ID` fallback).
+- The ArNS record must be active.
+- Closes the `PrimaryName` and `PrimaryNameReverse` accounts.
+
+### Record Owner Delegation Model
+
+The `set_record` instruction supports an optional `record_owner` field that enables delegated control over individual undername records. This is the "record owner" tier of the three-tier permission model:
+
+1. **NFT holder** -- full control over all records, controllers, and metadata.
+2. **Controllers** -- can manage all records (create, update, remove) and are set by the NFT holder or other controllers.
+3. **Record owners** -- can update content fields (`target`, `ttl_seconds`, metadata) on their assigned record only. Cannot change `priority`, cannot assign or transfer `record_owner`, and cannot create or remove records.
+
+**Stale owner cleanup:** When an NFT is transferred, record-level owners become stale (they were granted by the previous NFT holder). The program detects this by comparing the record's `last_reconciled_owner` against `AntConfig.last_known_owner`. On any write to a record where these differ, the record's `owner` is cleared and `last_reconciled_owner` is updated. This prevents inherited record-level permissions from surviving NFT transfers.
+
+### Controller Auto-Clear on NFT Transfer
+
+When the NFT changes hands (via marketplace sale, direct transfer, or any Metaplex Core transfer mechanism), the controller list is automatically cleared on the next write operation that touches the `AntConfig` and `AntControllers` accounts. This is implemented via lazy reconciliation:
+
+1. Every write instruction reads the current NFT holder from the Metaplex Core asset account.
+2. If the holder differs from `AntConfig.last_known_owner`, the `AntControllers.controllers` vector is cleared and `last_known_owner` is updated.
+3. The new NFT holder can then add their own controllers.
+
+This design ensures that transferring an ANT NFT is a clean handoff -- the new holder starts with no controllers and no stale record-level owners, while the NFT holder always retains full access by virtue of holding the NFT.

--- a/arns/arns-overview.md
+++ b/arns/arns-overview.md
@@ -1,8 +1,8 @@
-# Arweave Name System Specifications (ArNSS)
+# AR.IO Name System Specifications (ArNSS)
 
 ## Status:
 
-**In-Review**
+**Draft**
 
 ## Version:
 
@@ -10,123 +10,241 @@
 | ------- | ------------------------------------------------------------------- | ---------- |
 | 1.0.0   | Initial version of the Arweave Name System Specifications overview. | 2024-09-01 |
 | 1.0.1   | Updated reference implementation links                              | 2024-09-24 |
-| 1.0.2   | Added priority field for undernames and AR.IO Network integration. | 2025-07-29 |
+| 1.0.2   | Added priority field for undernames and AR.IO Network integration.  | 2025-07-29 |
 | 1.0.3   | Added undername ownership and delegated control features.           | 2025-08-01 |
+| 2.0.0   | Rebrand to AR.IO Name System, Solana migration, multi-protocol resolution. | 2026-04-20 |
+| 2.1.0   | Audit corrections: `NameRegistry` slot count, registry-side scope statement, pluggable ANT program note. | 2026-05-11 |
+| 2.2.0   | Added Name Validation, Name Lifecycle, Primary Names concept; Architecture diagram, Program IDs lookup, Account Serialization, Events sections. | 2026-05-11 |
 
 ## Abstract
 
-These specifications outline the overview, structure, and operations of the Arweave Name System. They are used to create Arweave Name Tokens (ANTs), which are AO Processes utilized within the Arweave Name System (ArNS), and resolve them to Arweave identities and data. By defining both the standard and optional interfaces for these processes, this document aims to ensure consistency and interoperability for developers integrating ANTs into their own processes or applications.
+These specifications outline the overview, structure, and operations of the AR.IO Name System. They define the creation and management of AR.IO Name Tokens (ANTs), which are Metaplex Core NFTs on Solana used within the AR.IO Name System (ArNS) to resolve human-readable names to content stored on decentralized storage networks. By defining both the standard and optional interfaces for these tokens and the programs that manage them, this document aims to ensure consistency and interoperability for developers integrating ANTs into their own applications.
 
 ## Motivation
 
-The building blocks in the Arweave Name Specifications ensure that ArNS can serve a broad spectrum of use cases, from simple name resolution to complex, multi-layered digital services and AO processes. This could include custom logic or interfaces suited to particular user groups or technical requirements. Developers can utilize the open protocols and APIs in these specifications to create resolvers and Arweave Name Processes tailored to specific applications or networks.
+The building blocks in the AR.IO Name Specifications ensure that ArNS can serve a broad spectrum of use cases, from simple name resolution to complex, multi-layered digital services. This could include custom resolution logic or interfaces suited to particular user groups or technical requirements. Developers can utilize the open protocols and APIs in these specifications to create resolvers and name management tooling tailored to specific applications or networks.
 
-For instance, a resolver could be built to integrate with decentralized applications on other blockchain platforms or to support enhanced security features like cryptographic validation of name queries.
+For instance, a resolver could be built to integrate with decentralized applications on other blockchain platforms, to support enhanced security features like cryptographic validation of name queries, or to resolve content across multiple storage protocols.
 
-By extending the utility of ArNS across different technologies, developers can further enhance its overall interoperability and flexibility.
+By extending the utility of ArNS across different technologies and storage networks, developers can further enhance its overall interoperability and flexibility.
 
-## Arweave Name System
+## AR.IO Name System
 
 ### Motivation
 
-Arweave Transaction IDs, Wallet IDs, and AO Process IDs, characterized by their length and complexity, present usability challenges for everyday applications. They are cumbersome to remember, share, and are often erroneously flagged as spam by filters.
+Arweave Transaction IDs, IPFS Content Identifiers (CIDs), and Solana addresses, characterized by their length and complexity, present usability challenges for everyday applications. They are cumbersome to remember, share, and are often erroneously flagged as spam by filters.
 
-The Arweave Name System (ArNS) addresses these issues by introducing a decentralized, censorship-resistant naming system built on the Arweave network. ArNS allows for the assignment of human-readable names to Arweave resources such as dApps, web pages, digital identities, or even AO processes.
+The AR.IO Name System (ArNS) addresses these issues by introducing a decentralized, censorship-resistant naming system built on the Solana blockchain. ArNS allows for the assignment of human-readable names to content stored on decentralized storage networks, starting with Arweave and extending to IPFS and future protocols. Names can point to dApps, web pages, files, digital identities, or any content addressable by a supported storage protocol.
 
-Using IO tokens for transactions and compatible with AR.IO gateway domains, ArNS simplifies access to Permaweb content, making it more navigable and user-friendly. It serves as a practical tool for enhancing user interactions on the network by replacing opaque identifiers with memorable names, thereby streamlining access and communication within the Permaweb.
+Using ARIO tokens (SPL tokens on Solana) for transactions and compatible with AR.IO gateway domains, ArNS simplifies access to permaweb content, making it more navigable and user-friendly. It serves as a practical tool for enhancing user interactions on the network by replacing opaque identifiers with memorable names, thereby streamlining access and communication across the decentralized web.
 
 ### Overview
 
 The ArNS system functions similarly to traditional DNS services, where users can purchase a name in a registry and DNS name servers resolve these names to IP addresses.
 
-- **Permanent and Lease-Based Name Registration**: Users can purchase names permanently or lease them for a defined period, depending on their needs. The registry is stored permanently on Arweave via AO, making it immutable and globally resilient.
-- **Wayback Machine for Data**: This permanent storage enables apps and infrastructure to not only read the latest state of the registry but also check any point in time in the past, creating a "Wayback Machine" of the permaweb.
+- **Permanent and Lease-Based Name Registration**: Users can purchase names permanently or lease them for a defined period, depending on their needs. The registry is stored on-chain via the `ario-arns` Solana program, making it immutable and globally resilient.
+- **Wayback Machine for Data**: The on-chain history enables applications and infrastructure to not only read the latest state of the registry but also audit any point in time in the past via Solana's ledger history, creating a "Wayback Machine" of the permaweb.
 
-- **Name Registration Process**: Users can register a name, like `ardrive`, within the ArNS Registry. Before owning a name, they must create an Arweave Name Process or Token (ANT)—an AO Compute-based token and open-source protocol used by ArNS to track ownership and control over the name. ANTs allow the owner to set a mutable pointer to any type of Permaweb data, such as a page, dApp, or file, via its Arweave Transaction ID.
+- **Name Registration Process**: Users can register a name, like `ardrive`, within the ArNS Registry. Before owning a name, they must create an AR.IO Name Token (ANT) -- a Metaplex Core NFT on Solana used by ArNS to track ownership and control over the name. ANTs allow the owner to set a mutable pointer to any type of permaweb data, such as a page, dApp, or file, via a content target. The target can be an Arweave Transaction ID, an IPFS CID, or an identifier for any future supported storage protocol.
 
-- **ArNS Resolvers**: Each AR.IO gateway acts as an ArNS Name resolver. They fetch the latest state of both the ArNS Registry and its associated ANTs from an AO Compute Unit (CU) and serve this information rapidly for apps and users. AR.IO gateways will also resolve that name as one of their own subdomains, e.g., `https://ardrive.arweave.net`, and proxy all requests to the associated Arweave Transaction ID. This ensures ANTs work across all AR.IO gateways or ArNS Resolvers that support them: `https://ardrive.g8way.io/`, `https://ardrive.ar.io`, etc.
+- **Multi-Protocol Content Resolution**: Each ANT record includes a `target` field (the content address) and a `targetProtocol` field that declares which storage protocol the target belongs to (`0` = Arweave, `1` = IPFS, with additional protocols addable via program upgrades). This enables a single ArNS name to serve content from different storage networks across its undernames. For example, the root record of `ardrive` could point to an Arweave Transaction ID while its `blog` undername points to an IPFS CID.
+
+- **ArNS Resolvers**: Each AR.IO gateway acts as an ArNS name resolver. Gateways read the latest state of both the ArNS Registry and its associated ANTs from the Solana blockchain and serve this information rapidly for applications and users. AR.IO gateways resolve names as subdomains of their gateway domain, e.g., `https://ardrive.ar.io`, and proxy requests to the associated content target on the appropriate storage network. This ensures ANTs work across all AR.IO gateways or ArNS Resolvers that support them: `https://ardrive.g8way.io/`, `https://ardrive.ar.io`, etc.
+
+- **Protocol-Agnostic URL Schemes**: The `ar://` prefix means "resolve via AR.IO gateway" and is protocol-agnostic -- the gateway determines the storage protocol from the ANT record's `targetProtocol` field. For example, `ar://ardrive` resolves through an AR.IO gateway regardless of whether the underlying content is on Arweave or IPFS. The `ipfs://` prefix is reserved for IPFS-specific resolution.
 
 - **User Accessibility**: Users can easily reference these friendly names in their browsers, and other applications and infrastructure can build rich solutions on top of these ArNS primitives.
 
-### Arweave Name System Registry
+### AR.IO Name System Registry
 
-The ArNS Registry is a list of all registered names and their associated Arweave Name Process IDs. There are two different types of name registrations that can be utilized based on the needs of the user:
+The ArNS Registry is a list of all registered names and their associated AR.IO Name Token mint addresses. The registry is managed by the `ario-arns` Solana program and supports on-chain enumeration via the `NameRegistry` zero-copy account (200,000 name slots). There are two different types of name registrations that can be utilized based on the needs of the user:
 
 - **Lease**: A name may be leased on a yearly basis. A leased name can have its lease extended or renewed, but only up to a maximum active lease of 5 years at any time.
 - **Permanent (Permabuy)**: A name may be purchased for an indefinite duration.
 
-Registering a name requires spending IO tokens corresponding to the name’s character length and purchase type. Key registry rules embedded within the smart contract include:
+Registering a name requires spending ARIO tokens corresponding to the name's character length and purchase type. Key registry rules embedded within the on-chain program include:
 
-- **Genesis Prices**: Set within the contract as starting conditions.
+- **Genesis Prices**: Set within the program as starting conditions.
 - **Dynamic Pricing**: Varies based on name length, purchase type (lease vs. buy), lease duration, and current Demand Factor.
-- **Name Records**: Include a pointer to the Arweave Name Process identifier, lease end time (if applicable), and undername allocation.
-- **Reassignment**: Name registrations can be reassigned from one Arweave Name Process to another.
-- **Lease Extension**: Anyone with available IO Tokens can extend any name’s active lease.
-- **Lease to Permanent Buy**: Anyone with available IO Tokens can convert a name’s lease to a permanent buy.
-- **Undername Capacity**: Additional undername capacity can be purchased for any actively registered name.
-- **Name Removal**: Name records can only be removed from the registry if a lease expires, or a permanent name is returned to the protocol.
+- **Name Records**: Include a pointer to the AR.IO Name Token mint address, lease end time (`None` for permabuy, `Some(timestamp)` for lease), and undername allocation.
+- **Reassignment**: The current name owner (the `ArnsRecord.owner`, set at purchase) can reassign the name to a different AR.IO Name Token.
+- **Lease Extension**: Permissionless -- any ARIO holder can pay to extend an active lease, up to 5 years remaining at any time.
+- **Lease to Permanent Buy**: Permissionless -- any ARIO holder can pay the upgrade fee to convert an active lease to a permanent buy.
+- **Undername Capacity**: Permissionless -- any ARIO holder can pay to add undername capacity to an active name.
+- **Name Removal**: Name records can only be removed from the registry if a lease expires, or a permanent name is returned to the protocol by its owner via `release_name`.
 
-### Arweave Name Tokens (ANTs)
+#### Name Validation
 
-Arweave Name Tokens (ANTs) are specialized AO Processes that manage the ownership, configuration, and data pointer records for names registered in ArNS. They facilitate the mapping of names to various types of Permaweb data—whether a webpage, dApp, or file—through their respective Arweave transaction IDs. They can be transferred as needed, like any other non-fungible token.
+ArNS names are validated on-chain at purchase:
 
-- **Process Control**: Each registered ArNS name points to the Process ID of an ANT. The owner of this ANT controls how the ArNS name functions. ANT owners can upgrade their processes as needed, or they can set the process Owner to null, rendering the process code immutable.
-- **Resolution**: AR.IO Gateways and other ArNS Resolvers read the state from these registered ANTs to properly resolve and serve the data they reference.
-- **AR.IO Network Integration**: ANTs include handlers to interact directly with the AR.IO Network Process, enabling owners to release names back to the registry, reassign names to other ANTs, and manage primary name associations.
+- 1 to 51 characters (inclusive).
+- Lowercase ASCII only: `[a-z0-9-]`.
+- Must start and end with an alphanumeric character (no leading/trailing hyphen).
+- A single character must be alphanumeric (no single-hyphen name).
+- **Names of exactly 43 characters are prohibited** — every Arweave address is 43 base64url characters, so disallowing this length prevents an ArNS name from colliding with the gateway's CID/TX-ID URL space.
+
+### AR.IO Name Tokens (ANTs)
+
+AR.IO Name Tokens (ANTs) are Metaplex Core NFTs on Solana that manage the ownership, configuration, and content pointer records for names registered in ArNS. They facilitate the mapping of names to content on decentralized storage networks -- whether a webpage, dApp, or file -- through content targets and their associated storage protocols. ANTs are true NFTs and can be transferred as needed using standard Solana NFT tooling.
+
+- **Token Ownership**: Each registered ArNS name points to the mint address of an ANT. The holder of this NFT controls how the ArNS name functions. ANT holders can manage records, add controllers, and update metadata. The NFT can be transferred to a new Solana wallet, which automatically grants the new holder full control (with lazy controller cleanup on transfer).
+- **Pluggable ANT Program**: Each ANT may declare a custom backing program via the `ANT Program` entry in its Metaplex Core Attributes plugin. Resolvers route PDA derivation through that program, falling back to the canonical `ARIO_ANT_PROGRAM_ID` when the trait is absent. This enables third-party ANT implementations without changing the registry side. See [ARNS-CORE-1 §Implementation Note](arns-core-1.md#implementation-note).
+- **On-Chain Configuration**: Each ANT has associated on-chain accounts managed by the `ario-ant` Solana program: an `AntConfig` (metadata, display name, ticker, logo, description, keywords), an `AntControllers` list (up to 10 delegated controller addresses), and `AntRecord` accounts for each undername (content target, target protocol, TTL, priority, and optional per-record metadata).
+- **Resolution**: AR.IO Gateways and other ArNS Resolvers read the state from these registered ANTs on Solana to properly resolve and serve the data they reference. The gateway inspects the `targetProtocol` field to determine which storage network to fetch content from.
+- **AR.IO Network Integration**: ANT owners can interact directly with the AR.IO network programs on Solana, enabling them to release names back to the registry, reassign names to other ANTs, and manage primary name associations.
 
 ### Undernames
 
-Undernames allow Arweave Name owners to create multiple subdomains for a registered ArNS name, providing flexibility and extended functionality.
+Undernames allow AR.IO Name owners to create multiple subdomains for a registered ArNS name, providing flexibility and extended functionality.
 
-- **Naming Conventions**: These are configured using underscores (`_`) instead of dots (`.`), emphasizing the hierarchical relationship directly controlled by the primary name owner—ensuring that `dapp_ardrive` is unmistakably tied to `ardrive`. Unlike traditional DNS, names resembling undernames cannot be registered independently within ArNS, avoiding potential confusion and spoofing.
+- **Naming Conventions**: These are configured using underscores (`_`) instead of dots (`.`), emphasizing the hierarchical relationship directly controlled by the primary name owner -- ensuring that `dapp_ardrive` is unmistakably tied to `ardrive`. Unlike traditional DNS, names resembling undernames cannot be registered independently within ArNS, avoiding potential confusion and spoofing.
 - **Priority Sorting**: Undernames can be assigned priority values to determine their sort order when served by gateways, helping owners organize and prioritize their subdomains effectively.
-- **Delegated Ownership**: ANT owners can delegate control of specific undernames to other users through record ownership. Record owners can manage their undername's transaction ID, TTL, metadata (display name, logo, description, keywords), and use it as a primary ArNS identity. The ANT owner retains ultimate authority over all records. This enables use cases like community management, marketplaces, and distributed collaboration.
+- **Delegated Ownership**: ANT owners can delegate control of specific undernames to other users through record-level ownership (the optional `owner` field on `AntRecord`). Record owners can manage their undername's `target`, `ttl_seconds`, and metadata, but cannot change `priority` or reassign ownership. The ANT NFT holder retains ultimate authority. This enables use cases like community management, marketplaces, and distributed collaboration.
+- **Mixed Protocols**: Each undername can independently target a different storage protocol. For example, the `@` (root) record could point to an Arweave Transaction ID while a `docs` undername points to an IPFS CID. The `targetProtocol` field on each record determines the storage network for that undername.
+
+### Primary Names
+
+A **primary name** is a wallet's display identity within the AR.IO ecosystem. When wallet `W` sets `ardrive_alice` as its primary, gateways and apps can render `W` as that name. Primary names are a two-way binding (forward: wallet → name; reverse: name → wallet) and require consent from both the requesting wallet and the name owner. The binding can be dissolved at any time by either party. Primary names are managed by the `ario-core` program; see [ARNS-MANAGE-1 §Primary Names](arns-manage-1.md#primary-names) for the full flow and instruction surface.
+
+### Name Lifecycle
+
+A name occupies exactly one state at a time. Transitions are driven by specific instructions or by time-based events at the next on-chain interaction.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Available
+    Available --> Live_Active: buy_name
+    Available --> Reserved: reserve_name (admin)
+    Reserved --> Live_Active: claim_reserved_name
+    Reserved --> Available: unreserve_name / expiry
+    Live_Active --> Live_Active: extend_lease / upgrade_name
+    Live_Active --> Live_Grace: lease end_timestamp passed
+    Live_Grace --> Live_Active: extend_lease
+    Live_Grace --> Returned: prune_name_to_returned (after 14d grace)
+    Live_Active --> Returned: release_name (permabuy only)
+    Returned --> Live_Active: buy_returned_name
+    Returned --> Available: prune_returned_names (14d auction over)
+```
+
+- **Available** — no `ArnsRecord` PDA exists for the name; anyone may register via `buy_name`.
+- **Reserved** — a `ReservedName` PDA exists (admin-set via `reserve_name`). Blocks open registration; may be claimed by a designated target wallet via `claim_reserved_name`, or released by `unreserve_name` / expiry.
+- **Live (Active)** — `ArnsRecord` exists and `(purchase_type == Permabuy) || (end_timestamp > now)`. The resolver serves the name.
+- **Live (Grace)** — `ArnsRecord` exists; lease has expired but `now < end_timestamp + 14 days`. The name is still resolvable (so users don't see immediate downtime); the owner may still `extend_lease`, but `reassign_name` is blocked.
+- **Returned** — `ReturnedName` PDA exists (lease past grace, or permabuy released). A 14-day decaying auction runs: price starts at `RETURNED_NAME_MAX_MULTIPLIER` (50×) of the base fee and decays linearly to 1× over the 14 days. After the auction, the name returns to Available via `prune_returned_names`.
+
+Key constants (`ario-arns`): `GRACE_PERIOD_SECONDS = 14d`, `RETURNED_NAME_DURATION_SECONDS = 14d`, `RETURNED_NAME_MAX_MULTIPLIER = 50`, `MAX_LEASE_LENGTH_YEARS = 5`.
 
 ### Name Resolution
 
-The Arweave Name System is designed so that registered names can be accessed across many top-level domain names, providing resiliency and censorship resistance.
+The AR.IO Name System is designed so that registered names can be accessed across many top-level domain names, providing resiliency and censorship resistance.
 
-- **Access**: Names registered on ArNS are accessed through standardized URLs formatted as subdomains of an ArNS Resolver, such as `https://ardrive.arweave.net`.
-- **Resolver Functionality**: ArNS Resolvers interact directly with AO Compute Units to fetch the latest state of the ArNS Registry and associated ANTs, so they can serve the most up-to-date data pointers found for a registered name.
-- **Gateway Integration**: AR.IO Gateways come with an ArNS Resolver out of the box, ensuring that ArNS names are consistently resolvable across any supporting gateway, extending their accessibility throughout the Arweave ecosystem. Additionally, they are incentivized to resolve registered ArNS names into actionable Arweave URLs via the AR.IO Observation and Incentive Protocol.
-
-### ANT Registry
-
-The Arweave Name Token Registry is a permissionless list that contains all ANTs and their current owner. While it is not required or used by the core ArNS protocols, it can be utilized by downstream applications to quickly surface name ownership information by looking up ANTs contained in this Registry.
-
-- **Utility**: While ANTs do not have to be in this registry for resolution or other functionality like lease extension, it helps the performance of applications that need to quickly show users just the ANTs they own.
-- **Updating**: ANTs can be added simply by passing along their `State` to the ANT Registry. This provides important information about the ANT, such as its current owners and controllers. This can be updated at any time, and it is recommended to update it on any transfer made by the ANT.
+- **Access**: Names registered on ArNS are accessed through standardized URLs formatted as subdomains of an ArNS Resolver, such as `https://ardrive.ar.io`.
+- **Resolver Functionality**: ArNS Resolvers read the latest state of the ArNS Registry and associated ANTs directly from the Solana blockchain, so they can serve the most up-to-date content pointers found for a registered name. The resolver inspects the `targetProtocol` field to route content retrieval to the correct storage network.
+- **Gateway Integration**: AR.IO Gateways come with an ArNS Resolver out of the box, ensuring that ArNS names are consistently resolvable across any supporting gateway, extending their accessibility throughout the decentralized web. Additionally, gateways are incentivized to resolve registered ArNS names into actionable content URLs via the AR.IO Observation and Incentive Protocol.
+- **On-Chain Enumeration**: The `NameRegistry` zero-copy account in the `ario-arns` program enables permissionless enumeration of all registered names directly from the Solana blockchain, without requiring an external indexer.
 
 ## Specification Framework
 
-The Arweave Name System Specifications span across several specs that can be composed to make custom resolvers, Arweave Name Token Processes or custom variations of them.
+The AR.IO Name System Specifications span across several specs that can be composed to make custom resolvers, AR.IO Name Token implementations, or custom variations of them.
 
-- **ARNS-TOKEN-1**: Specifies the creation and structure of Arweave Name Tokens, focusing on token functionality and metadata.
-- **ARNS-MANAGE-1**: Details the management and control features for Arweave Names, building on the core process specification.
-- **ARNS-CORE-1**: The foundational AO process specification for ArNS Name resolution, detailing the core requirements for resolvers.
-- **ARNS-RESOLVER-1**: Outlines the protocols for resolving and serving Arweave Names across the AR.IO network.
-- **ARNS-ROUTING-1**: Describes the `ar://` schema and routing protocols for accessing permanent data and domain names via AR.IO Gateways.
+- **ARNS-TOKEN-1**: Specifies the creation and structure of AR.IO Name Tokens as Metaplex Core NFTs, focusing on token functionality and metadata.
+- **ARNS-MANAGE-1**: Details the management and control features for AR.IO Names, including registry operations and ANT record management.
+- **ARNS-CORE-1**: The foundational on-chain program specification for ArNS name resolution, detailing the core requirements for resolvers.
+- **ARNS-RESOLVER-1**: Outlines the protocols for resolving and serving AR.IO Names across the AR.IO network, including the `ar://` and `ipfs://` URI schemes, multi-protocol content retrieval, and routing semantics. The `ar://` prefix is protocol-agnostic -- the target storage protocol is determined by the ANT record's `targetProtocol` field.
 
-Applications like `https://arns.ar.io` can leverage this framework via SDKs like the AR.IO SDK or extend them further to create a rich ecosystem of multi-functional AO processes and tooling that support the needs of ArNS name buying, management, and resolution.
+Applications like `https://arns.ar.io` can leverage this framework via SDKs like the AR.IO SDK or extend them further to create a rich ecosystem of tooling that supports the needs of ArNS name buying, management, and resolution.
 
-### Language of Implementation
+### Reference Implementation
 
-Many examples and references provided in the specification documents are written in Lua. This choice ensures compatibility with many AO Specs and Processes while making it easier for developers working within the AO and AR.IO ecosystems to implement and extend the functionalities defined by the ArNS specifications. The use of Lua also aligns with the existing infrastructure and toolsets used in the AOS environment.
+The specifications are designed to be implementation-agnostic. The reference implementation is built on Solana using Rust and the Anchor framework. Developers are not restricted to Rust or Solana when building custom resolvers or extending ArNS functionality, provided they adhere to the protocols and specifications outlined in these documents.
 
-However, developers are not restricted to using Lua exclusively when building new features or extending functionalities around ArNS. While Lua is recommended for direct integration with existing AO infrastructure, other programming languages can be used, provided they adhere to the protocols and specifications outlined in these documents.
+The core Solana programs that comprise the AR.IO network on-chain infrastructure are:
+
+- **ario-core** -- ARIO SPL Token (mint/transfer), user vaults (time-locked tokens), primary name resolution
+- **ario-gar** -- Gateway Address Registry, operator/delegate staking, epoch lifecycle, observation and incentive protocol
+- **ario-arns** -- ArNS name registry (buy/lease/permabuy), demand factor pricing, reserved/returned names, lease management
+- **ario-ant** -- AR.IO Name Token as Metaplex Core NFT, undername records, controller management
+
+> **Scope.** These specifications cover the ArNS interoperability surface: records, ANT management, and name resolution. Registry-side instructions on `ario-arns` (name purchase, lease management, reservations, demand-factor maintenance, pruning, and fund-from-stakes variants) are part of the protocol but are documented by the `ario-arns` IDL and the AR.IO SDK rather than these specs. The `ario-ant-escrow` program (trustless ANT/token escrow used during migration and for non-custodial custody) is also out of scope here.
+
+#### Architecture
+
+```mermaid
+flowchart LR
+    subgraph ario-arns
+        NR[NameRegistry<br/>zero-copy, 200k slots]
+        AR[ArnsRecord<br/>per-name PDA]
+        RV[ReturnedName / ReservedName<br/>lifecycle PDAs]
+    end
+
+    subgraph ario-ant
+        AC[AntConfig]
+        ACT[AntControllers]
+        REC[AntRecord<br/>per-undername]
+        META[AntRecordMetadata<br/>optional]
+    end
+
+    subgraph ario-core
+        PN[PrimaryName / PrimaryNameReverse]
+        VLT[Vaults, ARIO SPL]
+    end
+
+    Wallet[User Wallet] -->|holds| NFT[ANT NFT<br/>Metaplex Core Asset]
+    NFT -.->|companion PDAs| AC
+    NFT -.-> ACT
+    NFT -.-> REC
+    REC -.-> META
+    AR -->|ant pubkey| NFT
+    NR -->|enumerates| AR
+    Resolver[Resolver / Gateway] -->|reads| AR
+    Resolver -->|reads| NFT
+    Resolver -->|reads| REC
+    Resolver -->|reads| META
+```
+
+The asset's Metaplex Core Attributes plugin carries an `ANT Program` entry naming the program that owns its `AntConfig` / `AntControllers` / `AntRecord` / `AntRecordMetadata` PDAs. Resolvers route accordingly (see [ARNS-CORE-1 §Implementation Note](arns-core-1.md#implementation-note)).
+
+#### Program IDs
+
+These specifications do not pin program IDs in line — addresses move during deployment phases (devnet → testnet → mainnet). Implementations MUST source the current IDs from one of:
+
+- The published Anchor IDL for each program (`ario_core.json`, `ario_gar.json`, `ario_arns.json`, `ario_ant.json`). The `address` field in each IDL is authoritative.
+- The AR.IO SDK's exported constants (`@ar.io/sdk` → `ARIO_CORE_PROGRAM_ID`, `ARIO_ARNS_PROGRAM_ID`, `ARIO_ANT_PROGRAM_ID`, `ARIO_GAR_PROGRAM_ID`), which mirror the IDLs.
+- The `ANT Program` Attributes-plugin entry on a specific asset (per-asset BYO-ANT routing; see ARNS-CORE-1 §Implementation Note).
+
+The Metaplex Core program ID is the upstream standard and is stable: `CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d`.
+
+#### Account Serialization
+
+All AR.IO program accounts follow Anchor's conventions:
+
+1. **Discriminator** — every program account begins with an 8-byte discriminator equal to the first 8 bytes of `sha256("account:<StructName>")` (e.g., `sha256("account:AntConfig")[..8]`). Readers MUST verify the discriminator before interpreting account data.
+2. **Body** — the remainder is [Borsh-serialized](https://borsh.io/) per the struct definition published in the program's IDL. `Option<T>` is encoded as 1-byte tag (`0` = None, `1` = Some) followed by the encoded `T` when present. `Vec<T>` and `String` are length-prefixed (4-byte little-endian u32 length).
+3. **Event records** — events appear in transaction logs as `Program data: <base64>` lines. The decoded blob is `[discriminator(8) || borsh_payload]` where the discriminator is `sha256("event:<EventName>")[..8]`. See `#### Events` below.
+4. **Metaplex Core assets** — the ANT mint account follows the upstream AssetV1 layout (not Anchor-discriminated). Byte 0 is the Metaplex Core Key discriminator; bytes 1-32 are the current owner pubkey. Plugin chain follows; the `ANT Program` Attribute lives in the Attributes plugin entry.
+
+#### Events
+
+Every state-changing instruction on `ario-core`, `ario-gar`, `ario-arns`, and `ario-ant` emits an Anchor `#[event]` record via `emit!()` (Solana's `sol_log_data` syscall). Events are the recommended way for indexers, dApps, and resolvers to receive push-based updates without diffing account state.
+
+- Wire format: `Program data: <base64>` log line; decoded blob = `[discriminator(8) || borsh_payload]`.
+- Subscription: standard Solana `logsSubscribe` against the relevant program ID, or one-shot decoding of a confirmed transaction's `logMessages`.
+- Canonical decoder: the AR.IO SDK exposes `parseTransactionEvents(rpc, sig)` and `parseEventsFromLogs(logs)` (`@ar.io/sdk/solana`).
+- The full event surface (74+ events at time of writing) and per-event payload schemas are published with each program's IDL and in the AR.IO repo's `docs/EVENTS.md`. These specifications do not enumerate individual events because the event set evolves additively post-mainnet under the ABI policy of ADR-017.
 
 ### Implementations
 
-The following implementations act as blueprints for deploying Arweave Name Processes and Tokens in AOS or other platforms. Developers can utilize these files to layer on the specification they need onto their new or existing process.
+The following implementations serve as references for building ArNS-compatible resolvers, name tokens, and management tooling.
 
-- ARNS-RESOLVER-1 https://github.com/ar-io/arns-resolver (Typescript, Node.js, Docker)
-- ARNS-CORE-1 https://github.com/ar-io/ao-pilot/blob/develop/scripts/arns-core-1.lua (Lua)
-- ARNS-MANAGE-1 https://github.com/ar-io/ao-pilot/blob/develop/scripts/arns-manage-1.lua (Lua)
-- ARNS-TOKEN-1 https://github.com/ar-io/ar-io-ant-process (Lua)
-- AR.IO SDK https://github.com/ar-io/ar-io-sdk (Typescript)
+- ARNS-RESOLVER-1: AR.IO Gateways (ar-io-node) -- TypeScript, Node.js, Docker
+- ARNS-CORE-1: `ario-ant` Solana program -- Rust, Anchor
+- ARNS-MANAGE-1: `ario-ant` + `ario-arns` Solana programs -- Rust, Anchor
+- ARNS-TOKEN-1: Metaplex Core NFT on Solana
+- AR.IO SDK: https://github.com/ar-io/ar-io-sdk -- TypeScript (supports both Solana and legacy AO backends)
 
 ## References
 
-- The AO Token and Subledger Specification, which Arweave Name Tokens inherit https://hackmd.io/8DiMkhuNThOb_ooTWKqxaw#ao-Token-and-Subledger-Specification
-- AO Token implementation in lua https://github.com/permaweb/aos/blob/main/blueprints/token.lua
 - AR.IO White Paper https://whitepaper_ar-io.arweave.net/
+- Metaplex Core NFT Standard https://developers.metaplex.com/core
+- Solana Program Library (SPL) Token https://spl.solana.com/token
+- AR.IO SDK https://github.com/ar-io/ar-io-sdk

--- a/arns/arns-resolver-1.md
+++ b/arns/arns-resolver-1.md
@@ -2,23 +2,29 @@
 
 ## Status:
 
-**In-Review**
+**Draft**
 
 ## Version:
 
-| Version | Description                                           | Date       |
-| ------- | ----------------------------------------------------- | ---------- |
-| 1.0.0   | Initial version of the ARNS-RESOLVER-1 specification. | 2024-09-01 |
+| Version | Description                                                          | Date       |
+| ------- | -------------------------------------------------------------------- | ---------- |
+| 1.0.0   | Initial version of the ARNS-RESOLVER-1 specification.                | 2024-09-01 |
+| 2.0.0   | Solana migration: multi-protocol resolution, updated data model.     | 2026-04-20 |
+| 2.1.0   | Pluggable ANT program: AntRecord PDAs are derived against the program named in the asset's `ANT Program` Attributes-plugin entry. New `x-arns-ant-program` response header. | 2026-05-03 |
+| 2.1.1   | Audit corrections: `NameRegistry` slot count is 200,000 (not 50,000). | 2026-05-11 |
+| 2.1.2   | Added explicit `ArnsRecord` / `ReturnedName` / `ReservedName` PDA derivation; AntRecordMetadata fields split out of AntRecord listing; event-subscription guidance. | 2026-05-11 |
 
 ## Abstract
 
-The **ARNS-RESOLVER-1** specification defines the protocols and patterns that an ArNS Resolver must follow to accurately retrieve and serve the latest state of Arweave Names from the ArNS Registry. It ensures that names are correctly resolved to their associated data and process IDs within the AR.IO network.
+The **ARNS-RESOLVER-1** specification defines the protocols and patterns that an ArNS Resolver must follow to accurately retrieve and serve the latest state of AR.IO Names from the ArNS Registry. It ensures that names are correctly resolved to their associated content targets and AR.IO Name Token (ANT) identifiers within the AR.IO network, supporting multiple storage protocols (Arweave, IPFS, and future networks) through a single resolution layer.
 
 ## Motivation
 
-As resolvers are critical to ensuring that users can reliably access data associated with these names, this specification standardizes the process, enabling consistent behavior across different AR.IO gateways and infrastructure. This specification provides the necessary guidelines for developing resolvers that handle the retrieval and resolution of Arweave Names via their associated AO Processes.
+Resolvers are critical to ensuring that users can reliably access content associated with ArNS names. This specification standardizes the resolution process, enabling consistent behavior across different AR.IO gateways and infrastructure.
 
-By establishing clear protocols for pulling records, requesting process states, and handling undernames, **ARNS-RESOLVER-1** ensures that resolvers operate efficiently and securely. This foundation is crucial for maintaining the integrity and performance of the Arweave Name System, particularly as the ecosystem scales and more complex use cases emerge.
+With the migration from AO to Solana, the data model has changed: ArNS Registry records are now on-chain Solana accounts managed by the `ario-arns` program, and ANT records are PDA accounts managed by the `ario-ant` program. ANTs are Metaplex Core NFTs on Solana, and each ANT record carries a `target_protocol` field that declares which storage protocol the content address belongs to (Arweave, IPFS, or future protocols).
+
+By establishing clear protocols for reading registry state, resolving ANT records, routing by storage protocol, and caching results, **ARNS-RESOLVER-1** ensures that resolvers operate efficiently and securely. This foundation is crucial for maintaining the integrity and performance of the AR.IO Name System, particularly as the ecosystem scales to support multiple storage networks.
 
 ## Specification
 
@@ -26,47 +32,198 @@ By establishing clear protocols for pulling records, requesting process states, 
 
 The resolver must adhere to the following protocols to correctly identify, resolve, and serve ArNS names:
 
-- **Expired Names**: Must not serve names that have expired from the ArNS Registry.
+- **Expired Names**: Must not serve names that have expired from the ArNS Registry. The `ArnsRecord` account stores `purchase_type` (Lease or Permabuy) and `end_timestamp`. Leases with `end_timestamp < now` are expired and must not be served.
 - **Undernames**:
-  - Must not serve undernames (i.e., subdomains) beyond the amount purchased.
-  - Must not serve undernames that exceed the maximum DNS label limit.
-  - The maximum length of each label is 63 characters, and a full domain name can have a maximum of 253 characters.
-- **Root Record**: The Record `"@"` is used for the root of the ArNS Name. All undernames for a given name must be sorted alphabetically, with the root `@` being at the top.
-- **Regex Compliance**: Must not serve undernames that don't match the ArNS standard regex pattern.
+  - Must not serve undernames (i.e., subdomains) beyond the `undername_limit` purchased for the name.
+  - Must not serve undernames that exceed the maximum DNS label limit. The maximum length of each label is 63 characters, and a full domain name can have a maximum of 253 characters.
+  - The maximum undername length is 61 characters. Undernames must start with an alphanumeric character and may contain alphanumeric characters, hyphens, and underscores.
+- **Root Record**: The record with undername `"@"` is the root of the ArNS Name. All undernames for a given name must be sorted by priority, with the root `@` at priority 0.
+- **Regex Compliance**: Must not serve undernames that do not match the ArNS standard pattern: `^@$` or `^[a-zA-Z0-9]+[a-zA-Z0-9_-]*$`.
 - **Caching**:
-  - Must cache each undername for the time-to-live (TTL) associated with it.
-  - The minimum TTL is 900 seconds (15 minutes).
-- **Response Headers**: Must respond to requests with additional headers, `x-arns-process-id` and `x-arns-resolved-id`, which indicate the process ID and the ID that the name is resolving to. For example:
-  - `x-arns-process-id: tVBd6CHJD1L46sjFBb-Vmr2WHu6FzNyWKJnO42RT_lc`
-  - `x-arns-resolved-id: wHt7VINjV_oKGtb-f7yB-oajzNb9qTKzkVoFoXDFStI`
+  - Must cache each record for the time-to-live (TTL) stored in the record's `ttl_seconds` field.
+  - The on-chain minimum TTL is 60 seconds. The resolver SHOULD enforce a minimum cache TTL of 900 seconds (15 minutes) to reduce RPC load and improve performance.
+- **Multi-Protocol Resolution**: Must read the `target_protocol` field from each ANT record and route content fetching accordingly. See the [Multi-Protocol Resolution](#multi-protocol-resolution) section.
+- **Response Headers**: Must respond to requests with the following headers:
+  - `x-arns-ant-id` — the ANT's Metaplex Core NFT mint address on Solana (base58).
+  - `x-arns-ant-program` — the program ID resolved from the asset's `ANT Program` Attributes-plugin entry (or canonical `ARIO_ANT_PROGRAM_ID` when the trait is absent). Surfaces the BYO-ANT routing decision so observers can audit which program a given name resolved through.
+  - `x-arns-resolved-id` — the content target that the name resolved to (Arweave TX ID, IPFS CID, etc.).
+  - `x-arns-resolved-protocol` — the storage protocol used: `arweave` or `ipfs`.
+  - Example:
+    - `x-arns-ant-id: 7xKXjH7YCdMw5vZwmTpKNoBUtFbqRXEBiPRdHE3dBF3`
+    - `x-arns-ant-program: ARioAntProgXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+    - `x-arns-resolved-id: bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi`
+    - `x-arns-resolved-protocol: ipfs`
 
 ### Standard Operations
 
-#### 1. Pulling Records from the ArNS Registry
+#### 1. Reading Records from the ArNS Registry
 
-The resolver must pull all Records from the ArNS Registry by connecting to an AO Compute Unit. This provides the latest details such as:
+The resolver must read `ArnsRecord` accounts from the `ario-arns` program via Solana RPC (or the AR.IO SDK). Each `ArnsRecord` provides:
 
-- The associated process.
-- Lease or permabuy status.
-- The number of undernames allowed.
-- The expiration date of the name (if applicable).
+- The associated ANT (Metaplex Core NFT mint address).
+- Lease or permabuy status (`purchase_type`).
+- The number of undernames allowed (`undername_limit`).
+- The expiration timestamp (`end_timestamp`, present for leases; absent for permabuys).
+- The name owner (`owner`).
 
-#### 2. Requesting the State of the Process
+The resolver may read records individually by deriving the PDA from the name hash, or enumerate all active records via the `NameRegistry` zero-copy account. The AR.IO SDK provides helper methods for both patterns.
 
-For each Record, the resolver must request the State of its associated process. This includes important details such as:
+PDA derivation under the `ario-arns` program:
 
-- Ownership information.
-- Data pointers.
-- Time-to-live (TTL) settings for the given ArNS name.
+```
+ArnsRecord    seeds = ["arns_record",   sha256(name.toLowerCase())]
+ReturnedName  seeds = ["returned_name", sha256(name.toLowerCase())]
+ReservedName  seeds = ["reserved_name", sha256(name.toLowerCase())]
+NameRegistry  seeds = ["name_registry"]  (singleton, zero-copy)
+```
 
-If the process does not respond to the State request, the resolver will be unable to fully resolve its Records.
+A name is "live" (resolvable) iff an `ArnsRecord` PDA exists for it. Presence of a `ReturnedName` or `ReservedName` PDA without an `ArnsRecord` means the name is unregistered (auction or reservation only) and MUST NOT be served. See [Name Lifecycle](arns-overview.md#name-lifecycle) in ARNS-OVERVIEW for the full state model.
 
-#### 3. Local Storage of Data
+The resolver SHOULD subscribe to Solana WebSocket notifications (account subscriptions) for real-time updates to registry records, rather than relying solely on polling. This enables faster propagation of new registrations, transfers, and expirations.
 
-The resolver should store all retrieved information locally to facilitate easy lookups by users or downstream infrastructure, such as an AR.IO Gateway.
+#### 2. Reading ANT Record State
+
+For each ArNS name, the resolver MUST first determine which program owns the ANT's record PDAs. Each ANT carries an `ANT Program` entry in its Metaplex Core Attributes plugin (set at `CreateV1` time by the SDK and migration mint paths). The resolver:
+
+1. Fetches the ANT asset (`getAccountInfo(antMint)`).
+2. Walks the asset's plugin chain to read the `ANT Program` Attribute (key/value encoding per [ARNS-CORE-1 §Implementation Note](arns-core-1.md#implementation-note) — base58-encoded program address).
+3. Treats absence (or any parse failure) as a directive to use the canonical `ARIO_ANT_PROGRAM_ID`.
+4. Derives `AntRecord` PDAs against that program: `seeds = ["ant_record", antMint, sha256(undername.toLowerCase())]`.
+
+Reading `AntRecord` accounts uses Solana RPC (or the AR.IO SDK's `SolanaANTReadable.fromAsset(rpc, mint)` factory, which encapsulates the lookup). Each `AntRecord` PDA provides:
+
+- The content target (`target`) — an Arweave TX ID, IPFS CID, or other protocol-specific content address, up to 128 characters.
+- The storage protocol (`target_protocol`) — `0` for Arweave, `1` for IPFS, with higher values reserved for future protocols.
+- Time-to-live settings (`ttl_seconds`) — between 60 and 86,400 seconds (inclusive).
+- The undername (`undername`) — `"@"` for root, or a subdomain label.
+- Sort priority (`priority`) and optional delegated record owner (`owner`).
+- Optional descriptive metadata (`display_name`, `record_logo`, `record_description`, `record_keywords`) lives on a companion `AntRecordMetadata` PDA (seeds: `["ant_record_meta", mint, sha256(undername.lowercase())]`). Resolvers MAY skip reading this account when only resolution data is needed.
+
+If the ANT's record accounts cannot be read (e.g., the ANT mint does not exist, or the `@` record PDA does not exist under the resolved program), the resolver will be unable to fully resolve the name and MUST return an error or empty resolution. Resolvers MUST NOT silently retry against the canonical program when the asset names a third-party program — the assets's declared program is authoritative for that asset.
+
+#### 3. Local Caching
+
+The resolver should store all retrieved information locally to facilitate fast lookups by users or downstream infrastructure, such as an AR.IO Gateway.
+
+- **ArNS Registry records** should be cached and refreshed at a regular interval. A 15-minute refresh interval is the recommended default.
+- **ANT records** should be cached per-undername using the record's `ttl_seconds` value, with a resolver-enforced minimum of 900 seconds.
+- **Cache invalidation** may be triggered by Solana WebSocket account change notifications, enabling near-real-time updates without frequent polling.
+
+Cache keys should incorporate the name and undername. Each undername resolves to exactly one (protocol, target) pair, so the cache entry naturally includes the protocol.
+
+### Multi-Protocol Resolution
+
+#### Protocol Routing
+
+Each ANT record declares a `target_protocol` field that determines how the resolver fetches the referenced content:
+
+| `target_protocol` | Protocol | Target Format | Fetch Strategy |
+| --- | --- | --- | --- |
+| `0` | Arweave | 43-character base64url TX ID | Fetch from Arweave network via the gateway's existing Arweave data path. |
+| `1` | IPFS | CIDv0 (`Qm...`, exactly 46 chars) or CIDv1 (multibase-encoded, typically 46-64 chars) | Fetch from IPFS network via the gateway's IPFS sidecar or IPFS gateway. |
+| `2+` | Reserved | — | Unsupported. Resolver MUST NOT serve records with unrecognized protocols. Return 502 (Bad Gateway). |
+
+The resolver MUST read `target_protocol` for every record and route accordingly. It MUST NOT assume all targets are Arweave TX IDs.
+
+#### URI Semantics
+
+| URI Pattern | Behavior |
+| --- | --- |
+| `ar://name` | Resolve the ANT `@` record. Fetch content from whatever protocol the record specifies. `ar://` means "resolve via AR.IO gateway" — it is protocol-agnostic. |
+| `ar://name/undername` | Resolve the specified undername record. Route by its `target_protocol`. |
+| `ipfs://name` | Resolve the ANT `@` record. The resolver MUST verify that `target_protocol == 1` (IPFS). If the record's protocol is not IPFS, return 404. `ipfs://` is protocol-specific. |
+| `ipfs://name/undername` | Resolve the specified undername record. The resolver MUST verify that `target_protocol == 1` (IPFS). If the record's protocol is not IPFS, return 404. |
+
+#### Target Validation
+
+Before serving content, the resolver MUST validate the target value against the declared protocol:
+
+- **Arweave (protocol 0)**: Target must be exactly 43 characters, consisting of base64url characters (`[A-Za-z0-9_-]`).
+- **IPFS (protocol 1)**: Target must be a valid CID. Two forms are accepted:
+  - **CIDv0**: exactly 46 characters, starts with `Qm`, base58btc body.
+  - **CIDv1**: multibase-prefixed (`b`/`B`/`z`/`f`/`u`/`k`), at least 10 characters total, alphanumeric after the prefix byte.
+
+Invalid targets MUST NOT be served. The resolver should log a warning and return an error response.
+
+#### Graceful Degradation
+
+If a gateway does not yet support a record's declared protocol (e.g., a record points to IPFS but the gateway has no IPFS sidecar configured), the resolver SHOULD:
+
+1. Successfully resolve the name (return the ANT ID, target, and protocol in response headers).
+2. Return HTTP 502 (Bad Gateway) for the content fetch, indicating the protocol is not supported by this gateway.
+3. NOT return 404, which would imply the name does not exist.
+
+This allows clients to discover the content address and protocol even when the serving gateway cannot fetch the content.
+
+#### Subdomain Routing and Name/CID Disambiguation
+
+AR.IO gateways conventionally serve ArNS names at the apex subdomain: `<arns-name>.<gateway-host>` (e.g., `ardrive.arweave.net`). When a gateway also serves IPFS content, the resolver MUST avoid ambiguity between ArNS-name lookups and CID lookups.
+
+##### Why registry-level CID prohibition isn't needed
+
+ArNS name validation (per ARNS-CORE-1) already prevents every collision class that occurs in practice. The table below enumerates each IPFS CID form against ArNS validation rules:
+
+| CID form                          | Length    | Charset / shape                     | Collides with ArNS? |
+| --------------------------------- | --------- | ----------------------------------- | ------------------- |
+| CIDv0 (`Qm...`)                   | exactly 46 | starts with uppercase `Q`           | No — ArNS rejects uppercase |
+| CIDv1 sha-256 base32lower (`b...`) | ~59 chars | lowercase alphanumeric              | No — exceeds 51-char ArNS cap |
+| CIDv1 sha-256 base32upper (`B...`) | ~59 chars | uppercase alphanumeric              | No — both reasons |
+| CIDv1 sha-256 base58btc (`z...`)   | ~48 chars | mixed-case alphanumeric             | No — base58btc body almost certainly contains uppercase chars (probability of all-lowercase: ~10⁻¹³) |
+| CIDv1 sha-256 base16lower (`f...`) | ~70 chars | lowercase hex                       | No — exceeds ArNS cap |
+| CIDv1 sha-256 base64url (`u...`)   | ~47 chars | mixed-case + `_-`                   | No — practically always contains uppercase or underscore |
+| CIDv1 sha-256 base36lower (`k...`) | ~53 chars | lowercase alphanumeric              | No — exceeds ArNS cap |
+| CIDv1 with sha-1 multihash         | ~38 chars | varies                              | **Yes, theoretically** — the only residual collision class. Sha-1 is deprecated for new IPFS content. |
+
+The on-chain ArNS registry deliberately does NOT add CID-shape rejection rules beyond those above. A general "looks like a CID" check would have to reject any name starting with `b`, `f`, or `k` in a wide length range, which would block enormous numbers of legitimate names (`blog`, `bird`, `forum`, `kid`, `bookworm`, etc.) for vanishingly rare collision benefit. The 43-char Arweave-address prohibition works because every Arweave address is exactly 43 chars; CIDs have no equivalent narrow fingerprint.
+
+##### Recommended gateway pattern: path-style IPFS resolution
+
+To avoid the residual sha-1 collision and to avoid provisioning a second wildcard TLS certificate for `*.ipfs.<gateway-host>`, gateways SHOULD serve IPFS content via the path-style endpoint defined by the [IPFS Path Gateway specification](https://specs.ipfs.tech/http-gateways/path-gateway/):
+
+```
+<gateway-host>/ipfs/<cid>            ← IPFS content (path-style)
+<arns-name>.<gateway-host>           ← ArNS resolution (apex subdomain)
+```
+
+Path-style resolution removes ambiguity entirely: ArNS lookups and CID lookups occupy disjoint URL spaces. The existing wildcard certificate that covers `*.<gateway-host>` is sufficient — no additional certificates required.
+
+##### Apex-subdomain CID resolution (alternative)
+
+Gateways MAY also serve CIDs at the apex subdomain (`<cid>.<gateway-host>`) but MUST then implement and document an explicit disambiguation policy. The recommended policy is "ArNS-first":
+
+1. If `<id>` is exactly 46 chars and starts with `Qm` → resolve as CIDv0.
+2. If `<id>` length > 51 → resolve as CID (cannot be ArNS).
+3. If `<id>` length is exactly 43 → reject (Arweave-address rule).
+4. Otherwise: attempt ArNS lookup first. If the name is registered, serve it. If not registered AND `<id>` parses as a valid CID, fall back to IPFS fetch. Otherwise return 404.
+
+Under this policy, the only consequence is that a registered ArNS name which happens to also parse as a valid (rare) sha-1 CIDv1 will shadow that specific CID at the gateway's apex subdomain. The CID remains accessible via the path-style endpoint.
+
+##### Reserving operationally-significant names
+
+The `ario-arns` program exposes a `reserve_name` instruction (admin-only) that prevents a specific string from being registered. This is the appropriate tool for protecting individual sensitive strings — for example `ipfs`, `dweb`, `ar`, `gateway` — that have routing or branding significance for the gateway operator. Broader CID-shape rejection should not be encoded in the registry; targeted reservations should.
 
 ### Performance and Compliance
 
-The resolver is expected to perform the above actions in a timely manner to best serve users and/or to meet the standards defined in the AR.IO Observation and Incentive protocol.
+#### Data Source Performance
 
-For example, by default, the AR.IO ArNS Resolver fetches the ArNS Registry every 15 minutes, ensuring timely updates of new name additions and expirations. It is the responsibility of each ArNS Name owner to ensure their ANT code is functional and performant enough to be resolved.
+Solana RPC queries are significantly faster than the prior AO Compute Unit queries. The resolver benefits from:
+
+- **Direct account reads**: `ArnsRecord` and `AntRecord` PDAs are deterministically derivable and readable in a single RPC call.
+- **Batched reads**: Multiple records can be fetched in a single `getMultipleAccounts` RPC call.
+- **WebSocket subscriptions**: The resolver can subscribe to account changes for real-time cache invalidation, eliminating the need for frequent full-registry polling.
+- **Zero-copy registries**: The `NameRegistry` account (200,000 slots) enables full enumeration of all active names in a single read, useful for bootstrap and periodic reconciliation.
+- **Event log subscriptions**: All state-changing instructions on the `ario-arns`, `ario-ant`, and `ario-core` programs emit Anchor `#[event]` records (see [ARNS-OVERVIEW §Events](arns-overview.md#events)). Resolvers and indexers SHOULD subscribe via `logsSubscribe` rather than diffing account state; the canonical event ABI is published alongside each program's IDL.
+
+#### Refresh Cadence
+
+By default, the AR.IO ArNS Resolver should refresh the ArNS Registry at least every 15 minutes, ensuring timely updates of new name additions, transfers, and expirations. Resolvers using WebSocket subscriptions may operate with a longer polling interval as a fallback, since real-time updates are received via subscription.
+
+Individual ANT record caches should honor the record's `ttl_seconds` field, with a resolver-enforced minimum of 900 seconds.
+
+#### Observation Compliance
+
+The resolver is expected to perform the above actions in a timely manner to meet the standards defined in the AR.IO Observation and Incentive protocol:
+
+- At launch, observers test resolution of Arweave targets. IPFS observation support will be added in a future phase once gateways support IPFS content retrieval.
+- A future protocol capability bitmask on the Gateway struct (in the GAR) will allow gateways to declare which storage protocols they support. Until then, all gateways are expected to support Arweave resolution; IPFS resolution is opt-in at the gateway level.
+- It is the responsibility of each ArNS Name owner to ensure their ANT records contain valid, reachable content targets for the declared protocol.

--- a/arns/arns-token-1.md
+++ b/arns/arns-token-1.md
@@ -2,7 +2,7 @@
 
 ## Status:
 
-**In-Review**
+**Draft**
 
 ## Version:
 
@@ -13,26 +13,20 @@
 | 1.1.0   | Added 'description' and 'keywords' metadata.              | 2024-10-14 |
 | 1.2.0   | Added Set-Logo to action map, fixed Set-Keywords examples, and documented ANT Registry callback. | 2025-07-29 |
 | 1.3.0   | Added record ownership and metadata fields for undernames. | 2025-08-01 |
+| 2.0.0   | Rewritten for Solana: ANTs are Metaplex Core NFTs with on-chain PDA state. Removed Balances, Denomination, TotalSupply, Mint, Burn, Info handler, and AO messaging. Added lazy controller reconciliation, explicit reconcile instruction, and schema-versioned migration. | 2026-04-20 |
+| 2.0.1   | Audit corrections: description max 256, keywords max 8, `AntRecordMetadata` PDA documented as a separate account. | 2026-05-11 |
 
 ## Abstract
 
-The **ARNS-TOKEN-1** specification defines the framework for creating and managing Arweave Name Tokens (ANTs) with token transferability, balances, and metadata. It builds on the core and management specifications to introduce a non-fungible token model specific to ArNS.
+The **ARNS-TOKEN-1** specification defines the framework for creating and managing AR.IO Name Tokens (ANTs) as non-fungible assets on Solana. Each ANT is a Metaplex Core NFT whose ownership is determined by the NFT holder. Extended state -- metadata, controllers, and undername records -- is stored in Program Derived Address (PDA) accounts managed by the `ario-ant` program. This specification builds on the **ARNS-CORE-1** (records) and **ARNS-MANAGE-1** (controllers) specifications to provide a complete, self-contained token model for ArNS names.
 
 ## Motivation
 
-The **ARNS-TOKEN-1** specification builds off of the **ARNS-MANAGE-1** and **ARNS-CORE-1** specifications and provides a standardized approach for adding token-like features to Arweave Name Tokens (ANTs), enabling them to be transferred, tracked, and managed as single, indivisible assets.
+The **ARNS-TOKEN-1** specification provides a standardized approach for representing AR.IO Name Tokens as Metaplex Core NFTs on Solana, enabling them to be transferred, tracked, and managed as single, indivisible assets within the Solana ecosystem.
 
-By implementing this specification, developers can extend the functionality of Arweave Names to include ownership transfer, metadata management, and integration with external services like block explorers and marketplaces. This allows for more dynamic and flexible use cases within the Arweave ecosystem, such as tokenizing digital identities or assets on the Permaweb.
+By implementing this specification, developers can extend the functionality of AR.IO Names to include ownership transfer via any Solana wallet or marketplace, metadata management, and integration with block explorers and NFT tooling. The Metaplex Core standard ensures broad compatibility with the Solana ecosystem while the `ario-ant` program provides the ArNS-specific state (records, controllers, metadata) that makes each ANT functional as a name token.
 
-The **ARNS-TOKEN-1** Specification merges the protocols set in the AO Token and Subledger Specification except it is designed to act as a single, non-fungible token. This means that there is a total, indivisible token supply of 1 for each ANT, and transferring it changes both the balance and ownership.
-
-For more information on the AO Token and Subledger Specification see https://hackmd.io/8DiMkhuNThOb_ooTWKqxaw#ao-Token-and-Subledger-Specification
-
-### Language of Implementation
-
-All examples and code snippets in this specification are written in Lua. This choice ensures compatibility with the AO Processes and the Arweave ecosystem.
-
-However, developers are not restricted to using Lua exclusively when building new features or extending functionalities around ArNS. While Lua is recommended for direct integration with existing infrastructure, other programming languages can be used, provided they adhere to the protocols and specifications outlined in this document.
+Unlike the previous AO-based model -- which embedded a single-supply fungible token inside an AO Process -- the Solana model leverages the native NFT primitive. Ownership is determined by who holds the Metaplex Core asset. There is no Balances table, no Denomination, and no TotalSupply. Transfer is a standard Metaplex Core NFT transfer, compatible with any Solana marketplace or wallet.
 
 ## Specification
 
@@ -40,731 +34,435 @@ However, developers are not restricted to using Lua exclusively when building ne
 
 The **ARNS-TOKEN-1** Specification includes the following requirements:
 
-- Must have a `Name` which is a friendly nickname of this ANT.
-  - Must be a string, eg. `ArDrive`.
-- Must have a `Ticker` which is a short token symbol, shown in block explorers and marketplaces.
-  - Must be a string, eg. `ANT-ARDRIVE`.
-- Must have a `Logo` image icon used by downstream apps.
-  - Must be a string eg. `Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A`.
-  - Must be an Arweave transaction.
-- Must have a `Description` that is a brief description of this ANT and its purpose or use.  
-  - Must be a string eg. `ArDrive is a permaweb app that lets you upload, download and share your files easily.`
-  - Must not be longer than 512 characters.
-- Must have a table of `Keywords` used to further describe this ANT.
-  - `Keywords` must not contain more than 16 keywords.
-  - Each `Keyword` must be a string eg. `File-sharing`
-  - Each `Keyword` must consist of alphanumeric characters, dashes, underscores, @ or #.
-  - Each `Keyword` must not be longer than 32 characters.
-  - Each `Keyword` must not include spaces.
-  - Each `Keyword` must be unique in the table of `Keywords`.
-- Must have a `Denomination`, in compliance with the AO Token Blueprint, indicating the decimal places used by the token.
-  - Must be an integer.
-  - Must be set to 0, indicating no decimal places used by the Arweave Name Token.
-- Must have a `TotalSupply`, in compliance with the AO Token Blueprint, indicating the total amount of tokens minted.
-  - Must be an integer.
-  - Must be set to 1, indicating a single token in the supply.
-- Must have a `Balances` table which stores the current balance of minted Tokens.
-  - The Process `Owner` should be the only Token holder with a balance of 1.
-- Must have a `Balance` handler to read an individual user’s Token Balance.
-- Must have a `Balances` handler to read all Token Balances.
-- Must have a handler to Transfer the ANT.
-  - All Transfers move the single Token balance and Process Owner to the Recipient.
-  - Authorized for the Process `Owner` only.
-  - Transfer should have a `State` call-back message to the ANT Registry.
-- Must have an `Info` handler to read the Token metadata including `Name`, `Ticker`, `Total-Supply`, `Logo`, `Denomination`, `Description`, `Keywords` and `Owner`.
-  - `Total-Supply` must be returned as an integer string.
-  - `Denomination` must be returned as an integer string.
-- Must have a `Total-Supply `handler to calculate the total supply of outstanding Token balances.
-- Should have a `Set-Ticker` handler to change the ANT’s ticker.
-  - Authorized for the Process `Owner` and `Controllers`.
-- Should have a `Set-Name` handler to change the ANT’s name.
-  - Authorized for the Process `Owner` and `Controllers`.
-- Should have a `Set-Logo` handler to change the ANT’s logo.
-  - Authorized for the Process `Owner` and `Controllers`.
-- Should have a `Set-Description` handler to change the ANT’s description.
-  - Authorized for the Process `Owner` and `Controllers`.
-- Should have a `Set-Keywords` handler to change the ANT’s keywords.
-  - Authorized for the Process `Owner` and `Controllers`.
-- Handler to read entire ANT State must be updated to also return `Balances`, `Name`, `Ticker`, `Logo`, `Denomination`, `Description`, `Keywords` and `TotalSupply`.
+**Metadata (stored in an `AntConfig` PDA account, seeds: `["ant_config", mint]`):**
 
-The **ARNS-TOKEN-1** Specification does not include the ability to `Mint` or `Burn`; however, developers can extend ANTs to new functionality if needed.
+- Must have a `name` field which is a friendly name for this ANT.
+  - Must be a non-empty string, e.g., `"ArDrive"`.
+  - Must not exceed 61 characters.
+- Must have a `ticker` field which is a short token symbol, shown in block explorers and marketplaces.
+  - Must be a string, e.g., `"ANT-ARDRIVE"`.
+  - Must not exceed 16 characters.
+  - Defaults to `"ANT"` if not specified at initialization.
+- Must have a `logo` field which is an image icon used by downstream applications.
+  - Must be a valid Arweave transaction ID (43 base64url characters), e.g., `"Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A"`.
+  - Logos reference Arweave transactions exclusively, preserving the permanence guarantee.
+  - Defaults to the AR.IO logo (`"AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"`) if not specified at initialization.
+- Must have a `description` field that is a brief description of this ANT and its purpose or use.
+  - Must be a string, e.g., `"ArDrive is a permaweb app that lets you upload, download and share your files easily."`.
+  - Must not exceed 256 characters.
+- Must have a `keywords` field used to further describe this ANT.
+  - Must be an array of strings.
+  - Must not contain more than 8 keywords.
+  - Each keyword must not exceed 32 characters.
+  - Each keyword must consist of alphanumeric characters, dashes (`-`), underscores (`_`), `@`, or `#`.
+  - Each keyword must not include spaces.
+  - Each keyword must be unique within the array.
+- Must have a `last_known_owner` field that tracks the most recently observed NFT holder address.
+  - Used for lazy controller reconciliation (see Transfer section).
+- Must have a `version` field (unsigned 8-bit integer) indicating the schema version of this ANT's on-chain data.
+  - Used for per-ANT schema migrations via the `migrate_ant` instruction.
+
+**Ownership:**
+
+- Ownership is determined by the Metaplex Core NFT holder. The `ario-ant` program reads the owner directly from the Metaplex Core asset account data (AssetV1 layout: byte 0 is the Key discriminator, bytes 1-32 are the owner public key).
+- There is no Balances table, Denomination, or TotalSupply. These concepts from the AO token model do not apply to Metaplex Core NFTs.
+- There is no Mint or Burn capability within the `ario-ant` program. ANT minting is handled by the Metaplex Core program during asset creation; the `ario-ant` program's `initialize` instruction creates the associated PDA state after minting.
+
+**Transfer:**
+
+- Transfer is a standard Metaplex Core NFT transfer, executed via the Metaplex Core program (not a custom `ario-ant` instruction). This makes ANTs compatible with any Solana wallet or marketplace that supports Metaplex Core assets.
+- Upon the first `ario-ant` instruction executed after a transfer, the program detects that the NFT holder has changed (by comparing the on-chain NFT owner to `last_known_owner` in the `AntConfig` PDA). This triggers lazy reconciliation:
+  - All controllers are cleared from the `AntControllers` PDA.
+  - The `last_known_owner` field in `AntConfig` is updated to the new NFT holder.
+  - Record-level owners (`owner` field on `AntRecord` accounts) are cleared when their `last_reconciled_owner` differs from the updated `last_known_owner`.
+- A dedicated `reconcile` instruction is also available to explicitly trigger this reconciliation without performing any other operation. It is permissionless: anyone can call it for any ANT.
+- There are no Credit-Notice or Debit-Notice messages. Solana does not use AO-style inter-process messaging.
+
+**Metadata management instructions:**
+
+- Must have a `set_name` instruction to update the ANT's name.
+  - Authorized for the NFT holder or an authorized controller.
+- Must have a `set_ticker` instruction to update the ANT's ticker.
+  - Authorized for the NFT holder or an authorized controller.
+- Must have a `set_logo` instruction to update the ANT's logo.
+  - Must be a valid Arweave transaction ID (43 base64url characters).
+  - Authorized for the NFT holder or an authorized controller.
+- Must have a `set_description` instruction to update the ANT's description.
+  - Authorized for the NFT holder or an authorized controller.
+- Must have a `set_keywords` instruction to update the ANT's keywords.
+  - Authorized for the NFT holder or an authorized controller.
+
+**State reads:**
+
+- There is no `Info` handler or `State` handler. All ANT state is read directly from Solana accounts via RPC:
+  - `AntConfig` PDA -- metadata (name, ticker, logo, description, keywords, last_known_owner, version).
+  - `AntControllers` PDA -- controller list.
+  - `AntRecord` PDAs -- individual undername records (resolution-critical fields).
+  - `AntRecordMetadata` PDAs -- optional per-record metadata (lazy; absent when unset).
+  - Metaplex Core asset account -- current NFT holder (owner).
+- The complete state of an ANT is the union of these accounts.
+
+**ANT enumeration:**
+
+- The previous AO-based ANT Registry is replaced by on-chain account enumeration. Clients use Solana's `getProgramAccounts` RPC method with `memcmp` filters on the `ario-ant` program to discover all `AntConfig`, `AntControllers`, `AntRecord`, and `AntRecordMetadata` accounts.
+
+**Schema migration:**
+
+- Must have a `migrate_ant` instruction that upgrades an ANT's on-chain data layout to the latest schema version.
+  - Permissionless: anyone can pay to migrate any ANT. The instruction only upgrades the data layout and never changes user data.
+  - Uses Solana's `realloc` to handle account size changes between schema versions.
 
 ### Objects
 
-The **ARNS-TOKEN-1** specification leverages the general AO Token and Subledger specification, and includes all of the objects in **ARNS-MANAGE-1** and **ARNS-CORE-1**
+The **ARNS-TOKEN-1** specification stores state across multiple PDA accounts derived from the Metaplex Core asset's mint address. It includes all of the objects in **ARNS-MANAGE-1** (controllers) and **ARNS-CORE-1** (records).
 
-#### ARNS-TOKEN-1 Objects
+#### AntConfig
 
-```
--- ARNS-TOKEN-1 Objects
-Name = Name or "Arweave Name Token"
-Ticker = Ticker or "ANT"
-Description = Description or "This is an Arweave Name Token."
-Keywords = Keywords or {}
-Logo = Logo or "Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A"
-Denomination = Denomination or 0
-TotalSupply = TotalSupply or 1
+Per-ANT configuration and metadata. One account per ANT.
 
--- ARNS-MANAGE-1 Objects
-Owner = Owner or ao.env.Process.Owner
-Controllers = Controllers or { Owner }
+PDA seeds: `["ant_config", <mint>]`
 
--- ARNS-CORE-1 Objects
-Records = Records or {
-  ["@"] = {
-    transactionId = "UyC5P5qKPZaltMmmZAWdakhlDXsBF6qmyrbWYFchRTk",
-    ttlSeconds = 3600,
-    priority = 0,
-    -- Optional ownership and metadata fields
-    owner = nil,         -- Record owner address (optional)
-    displayName = nil,   -- Display name (max 61 chars, optional)
-    logo = nil,          -- Arweave TX ID for logo (optional)
-    description = nil,   -- Description (max 512 chars, optional)
-    keywords = nil       -- Array of keywords; up to 16, each max 32 chars (optional)
-  }
-}
-```
+| Field              | Type           | Description                                                |
+| ------------------ | -------------- | ---------------------------------------------------------- |
+| `mint`             | PublicKey      | The Metaplex Core asset (NFT mint) this config belongs to. |
+| `name`             | String         | ANT display name (max 61 characters).                      |
+| `ticker`           | String         | Ticker symbol (max 16 characters), e.g., `"ANT-ARDRIVE"`. |
+| `logo`             | String         | Arweave transaction ID (43 base64url characters).          |
+| `description`      | String         | Brief description (max 256 characters).                    |
+| `keywords`         | Vec\<String\>  | Up to 8 keywords, each max 32 characters.                  |
+| `last_known_owner` | PublicKey      | Last observed NFT holder, for lazy reconciliation.         |
+| `bump`             | u8             | PDA bump seed.                                             |
+| `version`          | u8             | Schema version for per-ANT data migrations.                |
 
-### Handlers
+#### AntControllers
 
-#### Action Map
+Controller list for an ANT. One account per ANT.
 
-The following actions are handled in the **ARNS-TOKEN-1** specification, and include all of the actions contained in **ARNS-MANAGE-1**, **ARNS-CORE-1**, and AO Token specifications.
+PDA seeds: `["ant_controllers", <mint>]`
 
-```
-ARNSCoreSpecActionMap = {
-  -- read actions
-  Record = "Record",
-  Records = "Records",
-  State = "State",
-}
+| Field         | Type             | Description                                                  |
+| ------------- | ---------------- | ------------------------------------------------------------ |
+| `mint`        | PublicKey        | The Metaplex Core asset this controller list belongs to.     |
+| `controllers` | Vec\<PublicKey\> | Controller addresses (max 10).                               |
+| `bump`        | u8               | PDA bump seed.                                               |
 
-ARNSManageSpecActionMap = {
-  -- read actions
-  Controllers = "Controllers",
-  -- write actions
-  AddController = "Add-Controller",
-  RemoveController = "Remove-Controller",
-  SetRecord = "Set-Record",
-  RemoveRecord = "Remove-Record",
-}
+#### AntRecord
 
-ARNSTokenSpecActionMap = {
-  -- write
-  SetName = "Set-Name",
-  SetTicker = "Set-Ticker",
-  SetDescription = "Set-Description",
-  SetKeywords = "Set-Keywords",
-  SetLogo = "Set-Logo"
-}
+A single undername record for an ANT. One account per undername per ANT. Contains resolution-critical fields only; optional descriptive metadata lives in a separate `AntRecordMetadata` PDA (below).
 
-TokenSpecActionMap = {
-  Info = "Info",
-  Balances = "Balances",
-  Balance = "Balance",
-  Transfer = "Transfer",
-  TotalSupply = "Total-Supply",
-  -- not implemented
-  Mint = "Mint",
-  Burn = "Burn",
-}
-```
+PDA seeds: `["ant_record", <mint>, <hash(undername.lowercase())>]`
 
-#### Set-Name
+| Field                  | Type                    | Description                                                          |
+| ---------------------- | ----------------------- | -------------------------------------------------------------------- |
+| `mint`                 | PublicKey               | The Metaplex Core asset this record belongs to.                      |
+| `undername`            | String                  | The undername (e.g., `"@"`, `"blog"`, `"docs"`), stored lowercase.   |
+| `target`               | String                  | Content address -- Arweave TX ID (43 chars), IPFS CID, or future protocol (max 128 chars). |
+| `target_protocol`      | u8                      | Storage protocol: `0` = Arweave, `1` = IPFS, `2+` = reserved.       |
+| `ttl_seconds`          | u32                     | TTL in seconds (60--86400).                                          |
+| `priority`             | Option\<u32\>           | Ordering priority. `Some(0)` required for `@`; `None` = unset.      |
+| `owner`                | Option\<PublicKey\>     | Optional record-level owner (delegated control).                     |
+| `last_reconciled_owner`| PublicKey               | ANT owner at last record modification; stale records are cleared.    |
+| `bump`                 | u8                      | PDA bump seed.                                                       |
+| `version`              | u8                      | Schema version for per-record data migrations.                       |
 
-Updates the `Name` or the nickname for the ANT.
+#### AntRecordMetadata
 
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+Optional descriptive metadata for a record. Created lazily when an optional field is first written. Resolvers MAY skip reading this account when only resolution data is needed.
 
-##### Parameters
+PDA seeds: `["ant_record_meta", <mint>, <hash(undername.lowercase())>]`
 
-| Name | Type   | Description               |
-| ---- | ------ | ------------------------- |
-| Name | string | The new Name for the ANT. |
+| Field                | Type                    | Description                                                       |
+| -------------------- | ----------------------- | ----------------------------------------------------------------- |
+| `mint`               | PublicKey               | The Metaplex Core asset this metadata belongs to.                 |
+| `display_name`       | Option\<String\>        | Optional display name (max 61 characters).                        |
+| `record_logo`        | Option\<String\>        | Optional logo (Arweave TX ID, 43 characters).                     |
+| `record_description` | Option\<String\>        | Optional description (max 256 characters).                        |
+| `record_keywords`    | Option\<Vec\<String\>\> | Optional keywords (same validation rules as ANT-level keywords).  |
+| `bump`               | u8                      | PDA bump seed.                                                    |
+| `version`            | u8                      | Schema version for per-record-metadata migrations.                |
 
-##### Rules
+### Instructions
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Name` parameter (string) as a message tag.
-- Should add `X-`forwarded tags to the response notice.
+#### Instruction Map
 
-##### Action
+The following instructions are provided by the `ario-ant` program. This list includes all instructions from the **ARNS-CORE-1** and **ARNS-MANAGE-1** specifications.
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Set-Name",
-  Name = "ArDrive"
-})
-```
+**From ARNS-CORE-1 (record management):**
 
-##### Responses
+| Instruction       | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `set_record`      | Create or update an undername record.              |
+| `remove_record`   | Remove an undername record (cannot remove `@`).    |
+| `transfer_record` | Transfer record-level ownership to another address.|
 
-**Permission error, not authorized**
+**From ARNS-MANAGE-1 (controller management):**
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Name-Notice",
-  Data = permissionErr,
-  Error = "Set-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+| Instruction          | Description                        |
+| -------------------- | ---------------------------------- |
+| `add_controller`     | Add a controller address.          |
+| `remove_controller`  | Remove a controller address.       |
 
-**Invalid parameters**
+**ARNS-TOKEN-1 (metadata management):**
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Name-Notice",
-  Data = nameRes,
-  Error = "Set-Name-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+| Instruction        | Description                        |
+| ------------------ | ---------------------------------- |
+| `set_name`         | Update ANT display name.           |
+| `set_ticker`       | Update ANT ticker symbol.          |
+| `set_description`  | Update ANT description.            |
+| `set_keywords`     | Update ANT keywords.               |
+| `set_logo`         | Update ANT logo.                   |
 
-**Valid parameters**
+**Lifecycle:**
 
-```
-{
-  Target = msg.From,
-  Action = "Set-Name-Notice",
-  Data = json.encode({ Name = Name }),
-  ... other forwarded tag name and value pairs
-}
-```
+| Instruction           | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `initialize`          | Initialize ANT state (config, controllers, `@` record).       |
+| `reconcile`           | Explicitly trigger lazy ownership reconciliation.              |
+| `migrate_ant`         | Upgrade ANT schema to latest version (permissionless).         |
 
-#### Set-Ticker
+#### initialize
 
-Updates the `Ticker` symbol for this ANT.
+Initializes an ANT's on-chain PDA state after a Metaplex Core asset has been minted. Creates the `AntConfig`, `AntControllers`, and root `@` record accounts.
 
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+Executable only by the current NFT holder.
 
 ##### Parameters
 
-| Name   | Type   | Description                 |
-| ------ | ------ | --------------------------- |
-| Ticker | string | The new Ticker for the ANT. |
+| Name             | Type           | Required | Description                                              |
+| ---------------- | -------------- | -------- | -------------------------------------------------------- |
+| `name`           | String         | Yes      | ANT display name (non-empty, max 61 characters).         |
+| `ticker`         | Option\<String\> | No    | Ticker symbol (max 16 characters). Defaults to `"ANT"`.  |
+| `target`           | String         | Yes      | Content target for the `@` record (Arweave TX ID, IPFS CID, etc., max 128 chars). |
+| `target_protocol`  | Option\<u8\>  | No       | Storage protocol (`0` = Arweave, `1` = IPFS). Defaults to `0` (Arweave). |
+| `logo`           | String         | No       | Arweave TX ID for logo. Empty string uses default logo.  |
+| `description`    | String         | No       | Description (max 256 characters). Can be empty.          |
+| `keywords`       | Vec\<String\>  | No       | Keywords (max 8, each max 32 chars). Can be empty.       |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Ticker` parameter (string) as a message tag.
-- Should add `X-`forwarded tags to the response notice.
+- Caller must be the current NFT holder (verified by reading the Metaplex Core asset's owner bytes).
+- The Metaplex Core asset account must be owned by the Metaplex Core program (`CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d`).
+- All PDA accounts (`AntConfig`, `AntControllers`, root `AntRecord`) must not already exist (enforced by Anchor's `init` constraint).
+- The NFT holder is added as the initial controller.
+- The root `@` record is created with `priority = Some(0)` and `ttl_seconds = 900` (default).
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Set-Ticker",
-  Ticker = "ANT-ARDRIVE"
-})
-```
+| Error Code       | Condition                                                    |
+| ---------------- | ------------------------------------------------------------ |
+| `NotNftHolder`   | Caller is not the NFT holder.                                |
+| `InvalidAsset`   | Asset account is not a valid Metaplex Core AssetV1.          |
+| `NameEmpty`      | Name is an empty string.                                     |
+| `NameTooLong`    | Name exceeds 61 characters.                                  |
+| `TickerTooLong`  | Ticker exceeds 16 characters.                                |
+| `InvalidTarget`  | Content target is not valid for the declared protocol.       |
+| `InvalidLogo`    | Logo is not a valid Arweave transaction ID.                  |
+| `DescriptionTooLong` | Description exceeds 256 characters.                      |
+| `InvalidKeyword` | Keywords fail validation (count, length, format, uniqueness).|
 
-##### Responses
+#### set_name
 
-**Permission error, not authorized**
+Updates the `name` field on the `AntConfig` PDA.
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Ticker-Notice",
-  Data = permissionErr,
-  Error = "Set-Ticker-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Ticker-Notice",
-  Data = tickerRes,
-  Error = "Set-Ticker-Error",
-  ["Message-Id"] = msg.Id,
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Set-Ticker-Notice",
-  Data = json.encode({ Ticker = Ticker }),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Set-Description
-
-Updates the `Description` of this ANT.
-
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+Executable by the NFT holder or an authorized controller.
 
 ##### Parameters
 
-| Name   | Type   | Description                 |
-| ------ | ------ | --------------------------- |
-| Description | string | The new Description for the ANT. |
+| Name   | Type   | Description                              |
+| ------ | ------ | ---------------------------------------- |
+| `name` | String | The new name for the ANT (max 61 chars). |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Description` parameter (string) as a message tag.
-- `Description` must not be longer than 512 characters.
-- Should add `X-`forwarded tags to the response notice.
+- Caller must be the NFT holder or an authorized controller.
+- Name must be a non-empty string.
+- Name must not exceed 61 characters.
+- Lazy reconciliation is performed before the permission check.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Set-Description",
-  Description = "ArDrive is an app that makes it easy to upload, download and share your public or private files on Arweave"
-})
-```
+| Error Code     | Condition                                          |
+| -------------- | -------------------------------------------------- |
+| `Unauthorized` | Caller is not the NFT holder or a controller.      |
+| `NameEmpty`    | Name is an empty string.                           |
+| `NameTooLong`  | Name exceeds 61 characters.                        |
 
-##### Responses
+#### set_ticker
 
-**Permission error, not authorized**
+Updates the `ticker` field on the `AntConfig` PDA.
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Description-Notice",
-  Data = permissionErr,
-  Error = "Set-Description-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Description-Notice",
-  Data = descriptionRes,
-  Error = "Set-Description-Error",
-  ["Message-Id"] = msg.Id,
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Set-Description-Notice",
-  Data = json.encode({ Description = Description }),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Set-Keywords
-
-Updates the `Keywords` of this ANT.
-
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+Executable by the NFT holder or an authorized controller.
 
 ##### Parameters
 
-| Name   | Type   | Description                 |
-| ------ | ------ | --------------------------- |
-| Keywords | table | The new Keywords for the ANT. |
+| Name     | Type   | Description                                  |
+| -------- | ------ | -------------------------------------------- |
+| `ticker` | String | The new ticker for the ANT (max 16 chars).   |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Keywords` parameter (table) as a message tag.
-- Each `Keyword` must not be longer than 32 characters.
-- Each `Keyword` must consist of alphanumeric characters, dashes, underscores, @ or #.
-- Each `Keyword` must not include spaces.
-- Each `Keyword` must be unique in the table of `Keywords`.
-- There must not be more than 16 total `Keywords`.
-- Should add `X-`forwarded tags to the response notice.
+- Caller must be the NFT holder or an authorized controller.
+- Ticker must be a non-empty string.
+- Ticker must not exceed 16 characters.
+- Lazy reconciliation is performed before the permission check.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Set-Keywords",
-  Keywords = json.encode(["file-sharing", "storage", "permaweb", "arweave"])
-})
-```
+| Error Code     | Condition                                          |
+| -------------- | -------------------------------------------------- |
+| `Unauthorized` | Caller is not the NFT holder or a controller.      |
+| `TickerEmpty`  | Ticker is an empty string.                         |
+| `TickerTooLong`| Ticker exceeds 16 characters.                      |
 
-##### Responses
+#### set_description
 
-**Permission error, not authorized**
+Updates the `description` field on the `AntConfig` PDA.
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Keywords-Notice",
-  Data = permissionErr,
-  Error = "Set-Keywords-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Keywords-Notice",
-  Data = keywordsRes,
-  Error = "Set-Keywords-Error",
-  ["Message-Id"] = msg.Id,
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Set-Keywords-Notice",
-  Data = json.encode({ Keywords = Keywords }),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Set-Logo
-
-Updates the `Logo` transaction ID for this ANT.
-
-Executable by the process `Owner` or an authorized user in the `Controllers` table.
+Executable by the NFT holder or an authorized controller.
 
 ##### Parameters
 
-| Name | Type   | Description                    |
-| ---- | ------ | ------------------------------ |
-| Logo | string | The new Logo transaction ID for the ANT. |
+| Name          | Type   | Description                                        |
+| ------------- | ------ | -------------------------------------------------- |
+| `description` | String | The new description for the ANT (max 256 chars).   |
 
 ##### Rules
 
-- Must be an authorized process `Owner` or `Controller`.
-- Must specify a valid `Logo` parameter (Arweave transaction ID) as a message tag.
-- Should add `X-`forwarded tags to the response notice.
+- Caller must be the NFT holder or an authorized controller.
+- Description must not exceed 256 characters. An empty string is permitted (clears the description).
+- Lazy reconciliation is performed before the permission check.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Set-Logo",
-  Logo = "KKmRbIfrc7wiLcG0zvY1etlO0NBx1926dSCksxCIN3A"
-})
-```
+| Error Code          | Condition                                          |
+| ------------------- | -------------------------------------------------- |
+| `Unauthorized`      | Caller is not the NFT holder or a controller.      |
+| `DescriptionTooLong`| Description exceeds 256 characters.                |
 
-##### Responses
+#### set_keywords
 
-**Permission error, not authorized**
+Updates the `keywords` field on the `AntConfig` PDA.
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Logo-Notice",
-  Data = permissionErr,
-  Error = "Set-Logo-Error",
-  ["Message-Id"] = msg.Id
-}
-```
-
-**Invalid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Set-Logo-Notice",
-  Data = logoRes,
-  Error = "Set-Logo-Error",
-  ["Message-Id"] = msg.Id,
-}
-```
-
-**Valid parameters**
-
-```
-{
-  Target = msg.From,
-  Action = "Set-Logo-Notice",
-  Data = json.encode({ Logo = Logo }),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Balance
-
-Returns the balance of a target; if a target is not supplied, then the balance of the sender of the message must be returned.
-
-Executable by anonymous users.
-
-AO Token Specification reference: https://hackmd.io/8DiMkhuNThOb_ooTWKqxaw#BalanceTarget--string
+Executable by the NFT holder or an authorized controller.
 
 ##### Parameters
 
-| Name      | Type   | Description                       |
-| --------- | ------ | --------------------------------- |
-| Recipient | string | The recipient to get balance for. |
+| Name       | Type          | Description                             |
+| ---------- | ------------- | --------------------------------------- |
+| `keywords` | Vec\<String\> | The new keywords for the ANT.           |
 
 ##### Rules
 
-- Must return entire `Balances` table as JSON in the data field of the response notice.
-- Should add `X-`forwarded tags to the response notice.
+- Caller must be the NFT holder or an authorized controller.
+- Must not contain more than 8 keywords.
+- Each keyword must not exceed 32 characters.
+- Each keyword must consist of alphanumeric characters, dashes (`-`), underscores (`_`), `@`, or `#`.
+- Each keyword must not include spaces.
+- Each keyword must be unique within the array.
+- An empty array is permitted (clears all keywords).
+- Lazy reconciliation is performed before the permission check.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Balances"
-})
-```
+| Error Code       | Condition                                                |
+| ---------------- | -------------------------------------------------------- |
+| `Unauthorized`   | Caller is not the NFT holder or a controller.            |
+| `InvalidKeyword` | Keywords fail validation (count, length, format, or uniqueness). |
 
-##### Responses
+#### set_logo
 
-**Valid `Balances`**
+Updates the `logo` field on the `AntConfig` PDA.
 
-```
-{
-  Target = msg.From,
-  Action = "Balances-Notice",
-  Data = json.encode(Balances),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Balances
-
-Gets the entire Balances table, including each token holder and their current balance.
-
-Executable by anonymous users.
-
-AO Token Specification reference: https://hackmd.io/8DiMkhuNThOb_ooTWKqxaw#Balances
-
-##### Rules
-
-- Must return entire `Balances` table as JSON in the data field of the response notice.
-- Should add `X-`forwarded tags to the response notice.
-
-##### Action
-
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Balances"
-})
-```
-
-##### Responses
-
-**Valid `Balances`**
-
-```
-{
-  Target = msg.From,
-  Action = "Balances-Notice",
-  Data = json.encode(Balances),
-  ... other forwarded tag name and value pairs
-}
-```
-
-#### Transfer
-
-If the sender is authorized, transfer ANT Ownership to the `Recipient`, issuing a `Credit-Notice` to the recipient and a `Debit-Notice` to the sender. If the sender is not authorized, fail and notify the sender.
-
-Additionally, the ARNS-TOKEN-1 specification modifies the AO Token transfer specification to accommodate its non-fungible, single token supply.
-
-It is executable only by the single Token `Balance` holder, process `Owner`, or Process itself.
-
-`Quantity` is no longer needed, since the ARNS-TOKEN-1 specification calls for a single token in the supply. `Transfer` will move the single token to the `Recipient`.
-
-Upon transfer, it also sets the `Recipient` of the token transfer to be the new `Owner` of the process, as well as clears out any previous `Controllers`.
-
-AO Token Specification reference: https://hackmd.io/8DiMkhuNThOb_ooTWKqxaw#TransferTarget-Quantity
+Executable by the NFT holder or an authorized controller.
 
 ##### Parameters
 
-| Name      | Type   | Description                                                                                                   |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| Recipient | string | The wallet address to transfer the ANT ownership and token, e.g., iKryOeZQMONi2965nKz528htMMN_sBcjlhc-VncoRjA |
+| Name   | Type   | Description                                              |
+| ------ | ------ | -------------------------------------------------------- |
+| `logo` | String | Arweave transaction ID (43 base64url characters).        |
 
 ##### Rules
 
-- Must be the ANT `Balance` holder, process `Owner`, or Process itself.
-- Must add `X-`forwarded tags to the `Credit-Notice` and `Debit-Notice` responses.
-- Should send a `State` notice to any associated ANT Registry Processes.
+- Caller must be the NFT holder or an authorized controller.
+- Logo must be a valid Arweave transaction ID: exactly 43 characters, each character alphanumeric or `-` or `_` (base64url encoding).
+- Lazy reconciliation is performed before the permission check.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Transfer",
-  Recipient = "{Wallet Address}"
-})
-```
+| Error Code     | Condition                                          |
+| -------------- | -------------------------------------------------- |
+| `Unauthorized` | Caller is not the NFT holder or a controller.      |
+| `InvalidLogo`  | Logo is not a valid 43-character Arweave TX ID.    |
 
-##### Responses
+#### Transfer (Metaplex Core)
 
-**Permission error, not authorized**
+ANT ownership transfer is a standard Metaplex Core NFT transfer. It is **not** an `ario-ant` program instruction. Any Solana wallet, marketplace, or application that supports Metaplex Core transfers can transfer an ANT.
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Transfer-Notice",
-  Data = permissionErr,
-  Error = "Transfer-Error",
-  ["Message-Id"] = msg.Id
-}
-```
+##### Behavior
 
-**Invalid parameters**
+1. The NFT is transferred using the Metaplex Core program's transfer instruction.
+2. The `ario-ant` program is not invoked during the transfer itself.
+3. On the next `ario-ant` instruction for this ANT (any instruction that reads the asset account), the program detects the ownership change by comparing the NFT holder to `AntConfig.last_known_owner`.
+4. Lazy reconciliation occurs automatically:
+   - `AntControllers.controllers` is cleared (empty array).
+   - `AntConfig.last_known_owner` is updated to the new NFT holder.
+5. On the next interaction with each `AntRecord`, if `record.last_reconciled_owner` differs from `config.last_known_owner`, the record's `owner` field is cleared and `last_reconciled_owner` is updated.
 
-```
-{
-  Target = msg.From,
-  Action = "Invalid-Transfer-Notice",
-  Data = transferResult,
-  Error = "Transfer-Error",
-  ["Message-Id"] = msg.Id,
-}
-```
+##### Explicit Reconciliation
 
-**Valid parameters**
+The `reconcile` instruction can be called to explicitly trigger ownership reconciliation without performing any other operation. This is useful after a marketplace transfer to ensure the ANT's state is clean before the new owner interacts with it.
 
-```
--- Debit-Notice message template, that is sent to the Sender of the transfer
-{
-  Target = msg.From,
-  Action = "Debit-Notice",
-  Recipient = msg.Tags.Recipient,
-  Quantity = msg.Tags.Quantity,
-  Data = "You transferred " .. msg.Tags.Quantity .. " to " .. msg.Tags.Recipient,
-}
--- Credit-Notice message template, that is sent to the Recipient of the transfer
-{
-  Target = msg.Tags.Recipient,
-  Action = "Credit-Notice",
-  Sender = msg.From,
-  Quantity = msg.Tags.Quantity,
-  Data = "You received " .. msg.Tags.Quantity .. " from " .. msg.From,
-}
-```
+- Permissionless: anyone can call `reconcile` for any ANT.
+- Idempotent: calling `reconcile` when no ownership change has occurred is a no-op.
 
-#### Info
+#### reconcile
 
-Returns all Token metadata associated with this process including its `Name`, `Ticker`, `Total-Supply`, `Logo`, `Denomination`, and process `Owner`.
+Explicitly triggers lazy ownership reconciliation. Clears controllers if NFT ownership has changed since the last recorded owner. Does not modify records (record-level reconciliation happens per-record on next interaction).
 
-Executable by anonymous users.
+Permissionless: anyone can call this for any ANT.
 
 ##### Parameters
 
-No parameters necessary.
+No parameters.
 
 ##### Rules
 
-- Must return general process information as encoded JSON in the data field and as tags of the response notice. Info JSON must include:
-  - Process `Owner`
-  - `Name`, `Ticker`, `Logo`, `Description`, and `Keywords`
-  - `Denomination` and `Total-Supply` as integer strings.
+- If `AntConfig.last_known_owner` differs from the current NFT holder, controllers are cleared and `last_known_owner` is updated.
+- If no ownership change is detected, the instruction is a no-op.
 
-##### Action
+#### migrate_ant
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "Info"
-})
-```
+Upgrades an ANT's on-chain data layout to the latest schema version. Uses Solana's `realloc` to handle account size changes between schema versions.
 
-##### Responses
-
-**Valid Info**
-
-```
-{
-  Target = msg.From,
-  Action = "Info-Notice",
-  Tags = {
-    Name = Name,
-    Ticker = Ticker,
-    ["Total-Supply"] = tostring(TotalSupply),
-    Logo = Logo,
-    Denomination = tostring(Denomination),
-    Owner = Owner,
-  },
-  Data = json.encode({
-    Name = Name,
-    Ticker = Ticker,
-    ["Total-Supply"] = tostring(TotalSupply),
-    Logo = Logo,
-    Denomination = tostring(Denomination),
-    Owner = Owner,
-    ["Source-Code-TX-ID"] = SourceCodeTxId,
-  })
-}
-```
-
-#### State
-
-The State handler is updated in **ARNS-TOKEN-1** to return all information about the state of the token, including all `Records`, `Owner`, `Controllers`, `Balances`, `Name`, `Ticker`, `Logo`, `Description`, `Keywords`, `Denomination`, and `TotalSupply`.
-
-Executable by anonymous users.
+Permissionless: anyone can pay the rent differential to migrate any ANT. The instruction only upgrades the data layout and never changes user data.
 
 ##### Parameters
 
-No parameters necessary.
+No parameters.
 
 ##### Rules
 
-- Must return the full state of the process as encoded JSON in the data field of the response notice. State information must include:
-  - Entire `Records` table (including optional record ownership and metadata fields: `owner`, `displayName`, `logo`, `description`, `keywords`)
-  - Entire `Controllers` table
-  - Entire `Balances` table
-  - Process `Owner`
-  - `Name`, `Ticker`, `Logo`, `Description` and `Keywords`
-  - `Denomination` and `TotalSupply`
-- Must add `X-`forwarded tags to the response notice.
+- The ANT's current `version` must be less than the program's `ANT_CONFIG_VERSION` constant.
+- The payer covers any rent increase from account reallocation.
 
-##### Action
+##### Errors
 
-```
-Send({
-  Target = "{Process Identifier}",
-  Action = "State"
-})
-```
+| Error Code            | Condition                                       |
+| --------------------- | ----------------------------------------------- |
+| `AlreadyLatestVersion`| ANT is already at the latest schema version.    |
 
-##### Responses
+#### State (Account Reads)
 
-**Valid `State`**
+There is no dedicated `State` or `Info` instruction. The full state of an ANT is read directly from Solana accounts via standard RPC calls:
 
-```
-{
-  Target = msg.From,
-  Action = "State-Notice",
-  Data = json.encode({
-    Records = Records,
-    Controllers = Controllers,
-    Balances = Balances,
-    Owner = Owner,
-    Name = Name,
-    Ticker = Ticker,
-    Logo = Logo,
-    Description = Description,
-    Keywords = Keywords,
-    Denomination = Denomination,
-    TotalSupply = TotalSupply,
-  }),
-  ... other forwarded tag name and value pairs
-}
-```
+| Account            | PDA Seeds                                                | Contents                                                       |
+| ------------------ | -------------------------------------------------------- | -------------------------------------------------------------- |
+| `AntConfig`         | `["ant_config", mint]`                                   | name, ticker, logo, description, keywords, last_known_owner, version |
+| `AntControllers`    | `["ant_controllers", mint]`                              | controller addresses                                           |
+| `AntRecord`         | `["ant_record", mint, hash(undername.lowercase())]`      | undername, target, target_protocol, ttl_seconds, priority, owner, last_reconciled_owner |
+| `AntRecordMetadata` | `["ant_record_meta", mint, hash(undername.lowercase())]` | display_name, record_logo, record_description, record_keywords (lazy; absent when no optional fields set) |
+| Metaplex Core Asset | (Asset mint address)                                     | Current NFT holder (owner)                                     |
+
+To enumerate all records for a given ANT, use `getProgramAccounts` with a `memcmp` filter matching the `mint` field in `AntRecord` accounts.
+
+To enumerate all ANTs, use `getProgramAccounts` with the `ario-ant` program ID and a `memcmp` filter on the account discriminator for `AntConfig`.


### PR DESCRIPTION
## Summary

- Wholesale rewrite of the ArNS specification set for the AO → Solana migration. ANTs are now Metaplex Core NFTs; ArNS state lives in on-chain PDA accounts managed by `ario-arns`, `ario-ant`, and `ario-core`.
- Multi-protocol resolution (Arweave + IPFS, with reserved values for future protocols) is now a first-class concern via a `target_protocol` field on every record.
- Pluggable ANT program (BYO-ANT) is documented per ADR-016 / BD-100: each asset declares its backing program via its Metaplex Core Attributes plugin; resolvers route accordingly with a canonical fallback.
- Three v2.x versions of each spec are stacked: 2.0.0 (Solana rewrite), 2.1.x (audit corrections + pluggable ANT), 2.2.0 (developer-experience additions: architecture diagram, lifecycle, validation, program-IDs lookup, serialization rules, events pointer).

## Per-spec changes

### ARNS-CORE-1
PDA-backed records; `AntRecord` (resolution-critical fields) split from a lazily-created `AntRecordMetadata` companion PDA; pinned `ANT Program` plugin key/value encoding; SDK and direct-RPC read examples.

### ARNS-TOKEN-1
ANTs as Metaplex Core NFTs. Removed AO concepts (Balances, Denomination, TotalSupply, Mint, Burn, Info, Credit/Debit notices). Added lazy controller reconciliation, permissionless `reconcile`, schema-versioned migration via `migrate_ant`.

### ARNS-MANAGE-1
Solana ANT management (`set_record`, `remove_record`, `transfer_record`, `add_controller`, `remove_controller`, `reconcile`). AR.IO Network integration documented end-to-end: `release_name`, `reassign_name` (on `ario-arns`), full primary-name flow `request_primary_name` / `approve_primary_name` / `remove_primary_name` / `remove_primary_name_for_base_name` (on `ario-core`). Per ADR-016, registry-side authorization is by the stored `owner` field on the on-chain record, **not** by current Metaplex Core NFT possession — resolvers and SDKs must keep these in sync.

### ARNS-RESOLVER-1
Direct on-chain account reads with explicit PDA derivation for `ArnsRecord`, `ReturnedName`, `ReservedName`, `NameRegistry`. `target_protocol` routing (Arweave / IPFS / reserved). New response headers including `x-arns-ant-program` (surfaces the BYO-ANT routing decision). Name/CID disambiguation policy; path-style IPFS recommendation; `reserve_name` framed as the right tool for protecting operationally-sensitive strings.

### ARNS-OVERVIEW
- **Architecture diagram** (Mermaid `flowchart LR`) showing the account graph across `ario-arns`, `ario-ant`, `ario-core`, the ANT NFT, and the resolver.
- **Name Lifecycle** state machine (Mermaid `stateDiagram-v2`): Available / Reserved / Live-Active / Live-Grace / Returned with all transitions.
- **Primary Names** concept (full flow detail lives in ARNS-MANAGE-1).
- **Name Validation** (1–51 chars, lowercase ASCII, 43-char prohibition to avoid Arweave-address collision).
- **Program IDs** lookup section pointing implementers at the IDLs and SDK constants (no addresses pinned in-line — specs stay durable across deployments).
- **Account Serialization** (Anchor 8-byte discriminator + Borsh encoding rules).
- **Events** pointer (wire format + subscription pattern; deferred to per-program IDLs and `docs/EVENTS.md` so the spec doesn't churn when events are added post-mainnet).

## Audit corrections incorporated

A bit-level audit against the `ario-arns` / `ario-ant` / `ario-core` programs in the [ar-io-solana-contracts](https://github.com/ar-io/ar-io-solana-contracts) repo corrected several earlier drafts:

- `NameRegistry` slot count is **200,000** (not 50,000).
- ANT description max is **256** characters (not 512).
- ANT/record keywords max is **8** (not 16).
- Registry-side authorization follows **ADR-016 / BD-100** — caller must match the stored `owner` field, not the Metaplex Core NFT holder.
- `AntRecordMetadata` is a separate PDA (`["ant_record_meta", mint, sha256(undername.lower())]`), not part of `AntRecord`.
- Lease extension, upgrade-to-permabuy, and undername-capacity increase are **permissionless** (any ARIO holder can pay), not name-owner-gated.
- `reassign_name` takes `new_ant` as an instruction argument (no on-chain Metaplex Core validation; SDKs should pre-check).

The v1.2.0 / 1.3.0 / 1.0.3 row from PR #9 (undername ownership) is preserved in each spec's change history; the v2.0.0 Solana rewrite carries forward those concepts (Transfer-Record → `transfer_record`, Record-Owner → `record_owner` field, per-record metadata → `AntRecordMetadata`).

## Test plan

Specs are documentation; no automated tests. Manual checks:

- [ ] Markdown renders on GitHub (Mermaid diagrams in `arns-overview.md` should display in the rendered view).
- [ ] All internal cross-references resolve (anchor links between specs).
- [ ] Spec content matches the deployed `ario-arns` / `ario-ant` / `ario-core` IDLs after mainnet deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)