### PR TITLE
docs(arns): correct specs to match on-chain contract

### DIFF
--- a/arns/arns-core-1.md
+++ b/arns/arns-core-1.md
@@ -14,6 +14,7 @@
 | 2.1.0   | Pluggable ANT program: record PDAs are derived against the program named in the asset's Metaplex Core Attributes plugin (`ANT Program` key). Canonical fallback when absent. | 2026-05-03 |
 | 2.1.1   | Audit corrections: keyword/description limits (8 / 256), AntRecordMetadata PDA split, sort/index is read-side, async `ANT.init`. | 2026-05-11 |
 | 2.1.2   | Pinned `ANT Program` plugin key/value encoding; Get State naming note. | 2026-05-11 |
+| 2.1.3   | Contract-drift corrections: keywords max 3, description max 128; non-root `priority` accepts any non-negative value (matches on-chain). | 2026-06-09 |
 
 ## Abstract
 
@@ -70,7 +71,7 @@ The **ARNS-CORE-1** specification includes the following requirements for valid,
 - The `ttlSeconds` value MUST be between 60 and 86400 seconds (inclusive). Resolvers SHOULD cache for at least 900 seconds regardless of the declared TTL.
 - Each record MAY include a `priority` value, which determines the sort order of undernames served by gateways.
 - The `priority` value for the root record (`@`) MUST be 0.
-- The `priority` value for non-root records MUST be an integer greater than 0, or omitted (unset). When omitted, the record is sorted lexicographically after all priority-assigned records.
+- The `priority` value for non-root records MUST be a non-negative integer (0 or greater), or omitted (unset). When omitted, the record is sorted lexicographically after all priority-assigned records.
 - The undername `@` denotes the root/base name record (i.e., the ArNS name itself with no subdomain prefix).
 - The record undername plus its ArNS name MUST NOT exceed 63 characters in total length.
 - Non-root undernames MUST match the regular expression `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` (must start with an alphanumeric character; remaining characters may be alphanumeric, hyphens, or underscores).
@@ -143,8 +144,8 @@ A record represents a single undername resolution entry within an ANT. On Solana
 | `owner`       | string or null   | Delegated record owner address. When set, this address can modify the record independently of the ANT owner. |
 | `displayName` | string or null   | Human-readable display name. Max 61 characters. |
 | `logo`        | string or null   | Logo image address (Arweave TX ID, 43 characters). |
-| `description` | string or null   | Free-text description. Max 256 characters. |
-| `keywords`    | array of strings or null | Keyword tags. Max 8 keywords, each max 32 characters. |
+| `description` | string or null   | Free-text description. Max 128 characters. |
+| `keywords`    | array of strings or null | Keyword tags. Max 3 keywords, each max 32 characters. |
 
 #### Record Examples
 

--- a/arns/arns-manage-1.md
+++ b/arns/arns-manage-1.md
@@ -15,6 +15,7 @@
 | 2.1.0   | Pluggable ANT program: management instructions live on the program named in the asset's `ANT Program` Attributes-plugin entry. Conformance is on the third-party program. | 2026-05-03 |
 | 2.1.1   | Audit corrections: ADR-016 authorization model for registry-side instructions (caller matches stored `owner`, not current NFT holder), `AntRecordMetadata` PDA split, description max 256, keywords max 8, `reassign_name` parameter clarification. | 2026-05-11 |
 | 2.1.2   | Documented full primary-name flow (`request_primary_name`, `remove_primary_name`); added Primary Names concept section and PDA seeds. | 2026-05-11 |
+| 2.1.3   | Contract-drift corrections: controllers max 4, keywords max 3, description max 128; `version` fields are a 3-byte `SchemaVersion`; `AntControllers` carries `version`; expiry-close instruction is `close_expired_request`; primary-name fee is a lease/permabuy split. | 2026-06-09 |
 
 ## Abstract
 
@@ -39,7 +40,7 @@ The **ARNS-MANAGE-1** specification requires the following capabilities:
 - Must maintain a list of `Controllers` -- addresses authorized to manage records on behalf of the NFT holder.
 - Must have an `add_controller` instruction to add new controllers.
   - Authorized for the NFT holder or existing controllers only.
-  - Maximum 10 controllers per ANT.
+  - Maximum 4 controllers per ANT.
 - Must have a `remove_controller` instruction to remove controllers.
   - Authorized for the NFT holder or existing controllers only.
 - Controllers must be automatically cleared when the NFT is transferred to a new holder (lazy reconciliation).
@@ -92,8 +93,9 @@ Stores the controller list for an ANT. Derived as a PDA with seeds `["ant_contro
 | Field       | Type      | Description                                        |
 | ----------- | --------- | -------------------------------------------------- |
 | mint        | PublicKey | The Metaplex Core asset (NFT mint) this belongs to |
-| controllers | PublicKey[] | Controller addresses (max 10)                    |
+| controllers | PublicKey[] | Controller addresses (max 4)                    |
 | bump        | u8        | PDA bump seed                                      |
+| version     | SchemaVersion | Schema version for migrations (3-byte: major/minor/patch) |
 
 #### AntRecord (extended from ARNS-CORE-1)
 
@@ -112,7 +114,7 @@ PDA seeds: `["ant_record", mint, hash(undername.lowercase())]`
 | owner                 | Option\<PublicKey\> | Delegated record owner. When set, this address can update content fields (target, ttl, metadata) but cannot change priority or record ownership |
 | last_reconciled_owner | PublicKey       | ANT owner at last record modification -- used to detect stale record owners after NFT transfer |
 | bump                  | u8              | PDA bump seed                                                            |
-| version               | u8              | Schema version for per-record migrations                                 |
+| version               | SchemaVersion | Schema version for per-record migrations                                 |
 
 #### AntRecordMetadata
 
@@ -123,10 +125,10 @@ PDA seeds: `["ant_record_meta", mint, hash(undername.lowercase())]`
 | mint               | PublicKey           | The Metaplex Core asset this metadata belongs to       |
 | display_name       | Option\<String\>    | Optional display name (max 61 chars)                   |
 | record_logo        | Option\<String\>    | Optional logo (Arweave TX ID, 43 chars)                |
-| record_description | Option\<String\>    | Optional description (max 256 chars)                   |
-| record_keywords    | Option\<String[]\>  | Optional keywords (max 8, each max 32 chars)           |
+| record_description | Option\<String\>    | Optional description (max 128 chars)                   |
+| record_keywords    | Option\<String[]\>  | Optional keywords (max 3, each max 32 chars)           |
 | bump               | u8                  | PDA bump seed                                          |
-| version            | u8                  | Schema version for per-record-metadata migrations      |
+| version            | SchemaVersion | Schema version for per-record-metadata migrations      |
 
 ### Instructions
 
@@ -167,7 +169,7 @@ Adds an address to the controller list, granting it permission to manage records
 
 - Caller must be the NFT holder or an existing controller (after lazy reconciliation).
 - The `controller` address must not already exist in the controller list.
-- The controller list must not exceed 10 entries.
+- The controller list must not exceed 4 entries.
 
 ##### Errors
 
@@ -175,7 +177,7 @@ Adds an address to the controller list, granting it permission to manage records
 | ------------------------ | ------------------------------------------ |
 | Unauthorized             | Caller is not the NFT holder or controller |
 | ControllerAlreadyExists  | Address is already a controller            |
-| MaxControllersReached    | Controller list already has 10 entries     |
+| MaxControllersReached    | Controller list already has 4 entries     |
 
 ---
 
@@ -226,8 +228,8 @@ Creates a new undername record or updates an existing one. This is the primary i
 | record_owner        | Option\<PublicKey\> | Optional delegated owner address. Only NFT holder / controllers can set or clear this         |
 | display_name        | Option\<String\>  | Optional display name for this record (max 61 chars)                                          |
 | record_logo         | Option\<String\>  | Optional logo (Arweave TX ID, 43 chars)                                                       |
-| record_description  | Option\<String\>  | Optional description (max 256 chars)                                                          |
-| record_keywords     | Option\<String[]\> | Optional keywords (max 8 keywords, each max 32 chars, no duplicates)                          |
+| record_description  | Option\<String\>  | Optional description (max 128 chars)                                                          |
+| record_keywords     | Option\<String[]\> | Optional keywords (max 3 keywords, each max 32 chars, no duplicates)                          |
 
 ##### Rules
 
@@ -421,7 +423,7 @@ PrimaryName         seeds = ["primary_name",          owner_pubkey]
 PrimaryNameReverse  seeds = ["primary_name_reverse",  sha256(name.toLowerCase())]
 ```
 
-A `PrimaryNameRequest` older than the configured expiry (default 7 days) is closed permissionlessly by `close_expired_primary_name_request`. Approving an expired request fails with `PrimaryNameRequestExpired`.
+A `PrimaryNameRequest` older than the configured expiry (default 7 days) is closed permissionlessly by `close_expired_request`. Approving an expired request fails with `PrimaryNameRequestExpired`.
 
 ---
 
@@ -442,7 +444,7 @@ Initiates a primary name request. The requestor (a normal user wallet) wishes to
 ##### Rules
 
 - The ArNS name must exist in the registry and be active (lease not expired).
-- The fee (`PRIMARY_NAME_REQUEST_BASE_FEE`, ~0.2 ARIO at genesis) is charged in ARIO tokens.
+- The fee is charged in ARIO tokens and depends on the name's purchase type: `PRIMARY_NAME_REQUEST_BASE_FEE_LEASE` (0.2 ARIO at genesis) for a leased name, or `PRIMARY_NAME_REQUEST_BASE_FEE_PERMABUY` (1.0 ARIO at genesis) for a permabuy — each scaled by the current ArNS demand factor.
 - Any existing `PrimaryNameRequest` for the requestor is overwritten.
 - Creates a `PrimaryNameRequest` with `expires_at = now + 7 days` (default).
 

--- a/arns/arns-overview.md
+++ b/arns/arns-overview.md
@@ -15,6 +15,7 @@
 | 2.0.0   | Rebrand to AR.IO Name System, Solana migration, multi-protocol resolution. | 2026-04-20 |
 | 2.1.0   | Audit corrections: `NameRegistry` slot count, registry-side scope statement, pluggable ANT program note. | 2026-05-11 |
 | 2.2.0   | Added Name Validation, Name Lifecycle, Primary Names concept; Architecture diagram, Program IDs lookup, Account Serialization, Events sections. | 2026-05-11 |
+| 2.2.1   | Contract-drift corrections: `NameRegistry` initial capacity is 50,000 (expandable, not 200,000); event ABI policy is ADR-018; whitepaper link moved off arweave.net; "previously the Arweave Name System" note. | 2026-06-09 |
 
 ## Abstract
 
@@ -34,7 +35,7 @@ By extending the utility of ArNS across different technologies and storage netwo
 
 Arweave Transaction IDs, IPFS Content Identifiers (CIDs), and Solana addresses, characterized by their length and complexity, present usability challenges for everyday applications. They are cumbersome to remember, share, and are often erroneously flagged as spam by filters.
 
-The AR.IO Name System (ArNS) addresses these issues by introducing a decentralized, censorship-resistant naming system built on the Solana blockchain. ArNS allows for the assignment of human-readable names to content stored on decentralized storage networks, starting with Arweave and extending to IPFS and future protocols. Names can point to dApps, web pages, files, digital identities, or any content addressable by a supported storage protocol.
+The AR.IO Name System (ArNS — previously the Arweave Name System; the acronym is retained) addresses these issues by introducing a decentralized, censorship-resistant naming system built on the Solana blockchain. ArNS allows for the assignment of human-readable names to content stored on decentralized storage networks, starting with Arweave and extending to IPFS and future protocols. Names can point to dApps, web pages, files, digital identities, or any content addressable by a supported storage protocol.
 
 Using ARIO tokens (SPL tokens on Solana) for transactions and compatible with AR.IO gateway domains, ArNS simplifies access to permaweb content, making it more navigable and user-friendly. It serves as a practical tool for enhancing user interactions on the network by replacing opaque identifiers with memorable names, thereby streamlining access and communication across the decentralized web.
 
@@ -57,7 +58,7 @@ The ArNS system functions similarly to traditional DNS services, where users can
 
 ### AR.IO Name System Registry
 
-The ArNS Registry is a list of all registered names and their associated AR.IO Name Token mint addresses. The registry is managed by the `ario-arns` Solana program and supports on-chain enumeration via the `NameRegistry` zero-copy account (200,000 name slots). There are two different types of name registrations that can be utilized based on the needs of the user:
+The ArNS Registry is a list of all registered names and their associated AR.IO Name Token mint addresses. The registry is managed by the `ario-arns` Solana program and supports on-chain enumeration via the `NameRegistry` zero-copy account (50,000 name slots at initial deploy; expandable post-deploy via `admin_expand_name_registry`). There are two different types of name registrations that can be utilized based on the needs of the user:
 
 - **Lease**: A name may be leased on a yearly basis. A leased name can have its lease extended or renewed, but only up to a maximum active lease of 5 years at any time.
 - **Permanent (Permabuy)**: A name may be purchased for an indefinite duration.
@@ -172,7 +173,7 @@ The core Solana programs that comprise the AR.IO network on-chain infrastructure
 ```mermaid
 flowchart LR
     subgraph ario-arns
-        NR[NameRegistry<br/>zero-copy, 200k slots]
+        NR[NameRegistry<br/>zero-copy, 50k slots (initial)]
         AR[ArnsRecord<br/>per-name PDA]
         RV[ReturnedName / ReservedName<br/>lifecycle PDAs]
     end
@@ -230,7 +231,7 @@ Every state-changing instruction on `ario-core`, `ario-gar`, `ario-arns`, and `a
 - Wire format: `Program data: <base64>` log line; decoded blob = `[discriminator(8) || borsh_payload]`.
 - Subscription: standard Solana `logsSubscribe` against the relevant program ID, or one-shot decoding of a confirmed transaction's `logMessages`.
 - Canonical decoder: the AR.IO SDK exposes `parseTransactionEvents(rpc, sig)` and `parseEventsFromLogs(logs)` (`@ar.io/sdk/solana`).
-- The full event surface (74+ events at time of writing) and per-event payload schemas are published with each program's IDL and in the AR.IO repo's `docs/EVENTS.md`. These specifications do not enumerate individual events because the event set evolves additively post-mainnet under the ABI policy of ADR-017.
+- The full event surface (74+ events at time of writing) and per-event payload schemas are published with each program's IDL and in the AR.IO repo's `docs/EVENTS.md`. These specifications do not enumerate individual events because the event set evolves additively post-mainnet under the ABI policy of ADR-018.
 
 ### Implementations
 
@@ -244,7 +245,7 @@ The following implementations serve as references for building ArNS-compatible r
 
 ## References
 
-- AR.IO White Paper https://whitepaper_ar-io.arweave.net/
+- AR.IO White Paper https://html_whitepaper.ar.io/
 - Metaplex Core NFT Standard https://developers.metaplex.com/core
 - Solana Program Library (SPL) Token https://spl.solana.com/token
 - AR.IO SDK https://github.com/ar-io/ar-io-sdk

--- a/arns/arns-resolver-1.md
+++ b/arns/arns-resolver-1.md
@@ -13,6 +13,7 @@
 | 2.1.0   | Pluggable ANT program: AntRecord PDAs are derived against the program named in the asset's `ANT Program` Attributes-plugin entry. New `x-arns-ant-program` response header. | 2026-05-03 |
 | 2.1.1   | Audit corrections: `NameRegistry` slot count is 200,000 (not 50,000). | 2026-05-11 |
 | 2.1.2   | Added explicit `ArnsRecord` / `ReturnedName` / `ReservedName` PDA derivation; AntRecordMetadata fields split out of AntRecord listing; event-subscription guidance. | 2026-05-11 |
+| 2.1.3   | Contract-drift corrections: `NameRegistry` initial capacity is 50,000 (expandable, not 200,000); undername regex anchor fix; example host moved off arweave.net. | 2026-06-09 |
 
 ## Abstract
 
@@ -38,7 +39,7 @@ The resolver must adhere to the following protocols to correctly identify, resol
   - Must not serve undernames that exceed the maximum DNS label limit. The maximum length of each label is 63 characters, and a full domain name can have a maximum of 253 characters.
   - The maximum undername length is 61 characters. Undernames must start with an alphanumeric character and may contain alphanumeric characters, hyphens, and underscores.
 - **Root Record**: The record with undername `"@"` is the root of the ArNS Name. All undernames for a given name must be sorted by priority, with the root `@` at priority 0.
-- **Regex Compliance**: Must not serve undernames that do not match the ArNS standard pattern: `^@$` or `^[a-zA-Z0-9]+[a-zA-Z0-9_-]*$`.
+- **Regex Compliance**: Must not serve undernames that do not match the ArNS standard pattern: `^@$` or `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`.
 - **Caching**:
   - Must cache each record for the time-to-live (TTL) stored in the record's `ttl_seconds` field.
   - The on-chain minimum TTL is 60 seconds. The resolver SHOULD enforce a minimum cache TTL of 900 seconds (15 minutes) to reduce RPC load and improve performance.
@@ -157,7 +158,7 @@ This allows clients to discover the content address and protocol even when the s
 
 #### Subdomain Routing and Name/CID Disambiguation
 
-AR.IO gateways conventionally serve ArNS names at the apex subdomain: `<arns-name>.<gateway-host>` (e.g., `ardrive.arweave.net`). When a gateway also serves IPFS content, the resolver MUST avoid ambiguity between ArNS-name lookups and CID lookups.
+AR.IO gateways conventionally serve ArNS names at the apex subdomain: `<arns-name>.<gateway-host>` (e.g., `ardrive.ar.io`). When a gateway also serves IPFS content, the resolver MUST avoid ambiguity between ArNS-name lookups and CID lookups.
 
 ##### Why registry-level CID prohibition isn't needed
 
@@ -211,7 +212,7 @@ Solana RPC queries are significantly faster than the prior AO Compute Unit queri
 - **Direct account reads**: `ArnsRecord` and `AntRecord` PDAs are deterministically derivable and readable in a single RPC call.
 - **Batched reads**: Multiple records can be fetched in a single `getMultipleAccounts` RPC call.
 - **WebSocket subscriptions**: The resolver can subscribe to account changes for real-time cache invalidation, eliminating the need for frequent full-registry polling.
-- **Zero-copy registries**: The `NameRegistry` account (200,000 slots) enables full enumeration of all active names in a single read, useful for bootstrap and periodic reconciliation.
+- **Zero-copy registries**: The `NameRegistry` account (50,000 slots at initial deploy, expandable) enables full enumeration of all active names in a single read, useful for bootstrap and periodic reconciliation.
 - **Event log subscriptions**: All state-changing instructions on the `ario-arns`, `ario-ant`, and `ario-core` programs emit Anchor `#[event]` records (see [ARNS-OVERVIEW §Events](arns-overview.md#events)). Resolvers and indexers SHOULD subscribe via `logsSubscribe` rather than diffing account state; the canonical event ABI is published alongside each program's IDL.
 
 #### Refresh Cadence

--- a/arns/arns-token-1.md
+++ b/arns/arns-token-1.md
@@ -15,6 +15,7 @@
 | 1.3.0   | Added record ownership and metadata fields for undernames. | 2025-08-01 |
 | 2.0.0   | Rewritten for Solana: ANTs are Metaplex Core NFTs with on-chain PDA state. Removed Balances, Denomination, TotalSupply, Mint, Burn, Info handler, and AO messaging. Added lazy controller reconciliation, explicit reconcile instruction, and schema-versioned migration. | 2026-04-20 |
 | 2.0.1   | Audit corrections: description max 256, keywords max 8, `AntRecordMetadata` PDA documented as a separate account. | 2026-05-11 |
+| 2.0.2   | Contract-drift corrections: keywords max 3, controllers max 4, description max 128; `version` fields are a 3-byte `SchemaVersion`; `AntControllers` carries `version`. | 2026-06-09 |
 
 ## Abstract
 
@@ -49,17 +50,17 @@ The **ARNS-TOKEN-1** Specification includes the following requirements:
   - Defaults to the AR.IO logo (`"AnYvLJTWcG9lr2Ll5MwYWZR2o5uTE39WbpYB0zCxwKM"`) if not specified at initialization.
 - Must have a `description` field that is a brief description of this ANT and its purpose or use.
   - Must be a string, e.g., `"ArDrive is a permaweb app that lets you upload, download and share your files easily."`.
-  - Must not exceed 256 characters.
+  - Must not exceed 128 characters.
 - Must have a `keywords` field used to further describe this ANT.
   - Must be an array of strings.
-  - Must not contain more than 8 keywords.
+  - Must not contain more than 3 keywords.
   - Each keyword must not exceed 32 characters.
   - Each keyword must consist of alphanumeric characters, dashes (`-`), underscores (`_`), `@`, or `#`.
   - Each keyword must not include spaces.
   - Each keyword must be unique within the array.
 - Must have a `last_known_owner` field that tracks the most recently observed NFT holder address.
   - Used for lazy controller reconciliation (see Transfer section).
-- Must have a `version` field (unsigned 8-bit integer) indicating the schema version of this ANT's on-chain data.
+- Must have a `version` field (a 3-byte `SchemaVersion`: `major`, `minor`, `patch` `u8`s) indicating the schema version of this ANT's on-chain data.
   - Used for per-ANT schema migrations via the `migrate_ant` instruction.
 
 **Ownership:**
@@ -128,11 +129,11 @@ PDA seeds: `["ant_config", <mint>]`
 | `name`             | String         | ANT display name (max 61 characters).                      |
 | `ticker`           | String         | Ticker symbol (max 16 characters), e.g., `"ANT-ARDRIVE"`. |
 | `logo`             | String         | Arweave transaction ID (43 base64url characters).          |
-| `description`      | String         | Brief description (max 256 characters).                    |
-| `keywords`         | Vec\<String\>  | Up to 8 keywords, each max 32 characters.                  |
+| `description`      | String         | Brief description (max 128 characters).                    |
+| `keywords`         | Vec\<String\>  | Up to 3 keywords, each max 32 characters.                  |
 | `last_known_owner` | PublicKey      | Last observed NFT holder, for lazy reconciliation.         |
 | `bump`             | u8             | PDA bump seed.                                             |
-| `version`          | u8             | Schema version for per-ANT data migrations.                |
+| `version`          | SchemaVersion | Schema version for per-ANT data migrations.                |
 
 #### AntControllers
 
@@ -143,8 +144,9 @@ PDA seeds: `["ant_controllers", <mint>]`
 | Field         | Type             | Description                                                  |
 | ------------- | ---------------- | ------------------------------------------------------------ |
 | `mint`        | PublicKey        | The Metaplex Core asset this controller list belongs to.     |
-| `controllers` | Vec\<PublicKey\> | Controller addresses (max 10).                               |
+| `controllers` | Vec\<PublicKey\> | Controller addresses (max 4).                               |
 | `bump`        | u8               | PDA bump seed.                                               |
+| `version`     | SchemaVersion    | Schema version for migrations (3-byte: major/minor/patch).  |
 
 #### AntRecord
 
@@ -163,7 +165,7 @@ PDA seeds: `["ant_record", <mint>, <hash(undername.lowercase())>]`
 | `owner`                | Option\<PublicKey\>     | Optional record-level owner (delegated control).                     |
 | `last_reconciled_owner`| PublicKey               | ANT owner at last record modification; stale records are cleared.    |
 | `bump`                 | u8                      | PDA bump seed.                                                       |
-| `version`              | u8                      | Schema version for per-record data migrations.                       |
+| `version`              | SchemaVersion | Schema version for per-record data migrations.                       |
 
 #### AntRecordMetadata
 
@@ -176,10 +178,10 @@ PDA seeds: `["ant_record_meta", <mint>, <hash(undername.lowercase())>]`
 | `mint`               | PublicKey               | The Metaplex Core asset this metadata belongs to.                 |
 | `display_name`       | Option\<String\>        | Optional display name (max 61 characters).                        |
 | `record_logo`        | Option\<String\>        | Optional logo (Arweave TX ID, 43 characters).                     |
-| `record_description` | Option\<String\>        | Optional description (max 256 characters).                        |
+| `record_description` | Option\<String\>        | Optional description (max 128 characters).                        |
 | `record_keywords`    | Option\<Vec\<String\>\> | Optional keywords (same validation rules as ANT-level keywords).  |
 | `bump`               | u8                      | PDA bump seed.                                                    |
-| `version`            | u8                      | Schema version for per-record-metadata migrations.                |
+| `version`            | SchemaVersion | Schema version for per-record-metadata migrations.                |
 
 ### Instructions
 
@@ -235,8 +237,8 @@ Executable only by the current NFT holder.
 | `target`           | String         | Yes      | Content target for the `@` record (Arweave TX ID, IPFS CID, etc., max 128 chars). |
 | `target_protocol`  | Option\<u8\>  | No       | Storage protocol (`0` = Arweave, `1` = IPFS). Defaults to `0` (Arweave). |
 | `logo`           | String         | No       | Arweave TX ID for logo. Empty string uses default logo.  |
-| `description`    | String         | No       | Description (max 256 characters). Can be empty.          |
-| `keywords`       | Vec\<String\>  | No       | Keywords (max 8, each max 32 chars). Can be empty.       |
+| `description`    | String         | No       | Description (max 128 characters). Can be empty.          |
+| `keywords`       | Vec\<String\>  | No       | Keywords (max 3, each max 32 chars). Can be empty.       |
 
 ##### Rules
 
@@ -257,7 +259,7 @@ Executable only by the current NFT holder.
 | `TickerTooLong`  | Ticker exceeds 16 characters.                                |
 | `InvalidTarget`  | Content target is not valid for the declared protocol.       |
 | `InvalidLogo`    | Logo is not a valid Arweave transaction ID.                  |
-| `DescriptionTooLong` | Description exceeds 256 characters.                      |
+| `DescriptionTooLong` | Description exceeds 128 characters.                      |
 | `InvalidKeyword` | Keywords fail validation (count, length, format, uniqueness).|
 
 #### set_name
@@ -324,12 +326,12 @@ Executable by the NFT holder or an authorized controller.
 
 | Name          | Type   | Description                                        |
 | ------------- | ------ | -------------------------------------------------- |
-| `description` | String | The new description for the ANT (max 256 chars).   |
+| `description` | String | The new description for the ANT (max 128 chars).   |
 
 ##### Rules
 
 - Caller must be the NFT holder or an authorized controller.
-- Description must not exceed 256 characters. An empty string is permitted (clears the description).
+- Description must not exceed 128 characters. An empty string is permitted (clears the description).
 - Lazy reconciliation is performed before the permission check.
 
 ##### Errors
@@ -337,7 +339,7 @@ Executable by the NFT holder or an authorized controller.
 | Error Code          | Condition                                          |
 | ------------------- | -------------------------------------------------- |
 | `Unauthorized`      | Caller is not the NFT holder or a controller.      |
-| `DescriptionTooLong`| Description exceeds 256 characters.                |
+| `DescriptionTooLong`| Description exceeds 128 characters.                |
 
 #### set_keywords
 
@@ -354,7 +356,7 @@ Executable by the NFT holder or an authorized controller.
 ##### Rules
 
 - Caller must be the NFT holder or an authorized controller.
-- Must not contain more than 8 keywords.
+- Must not contain more than 3 keywords.
 - Each keyword must not exceed 32 characters.
 - Each keyword must consist of alphanumeric characters, dashes (`-`), underscores (`_`), `@`, or `#`.
 - Each keyword must not include spaces.


### PR DESCRIPTION
## Summary

Verified all five ArNS specs (`overview`, `core-1`, `manage-1`, `resolver-1`, `token-1`) field-by-field against the deployed `ario-ant` / `ario-arns` / `ario-core` source and corrected the drift. The structural surface (instruction names, error names, PDA seeds, validation rules, lifecycle constants, primary-name flow, MPL Core ID) was already accurate — the drift was concentrated in **numeric limits the contract tightened *after* the specs' last audit pass**, plus a few type/citation/naming slips.

## Corrections

| # | Item | Was | Now (on-chain) | Source |
|---|---|---|---|---|
| 1 | ANT keywords (max) | 8 | **3** | `ario-ant/state.rs:79` |
| 1 | ANT controllers (max) | 10 | **4** | `state.rs:89` |
| 1 | ANT description (max chars) | 256 | **128** | `state.rs:73` |
| 2 | `NameRegistry` slots | 200,000 | **50,000 initial, expandable** | ADR-024; `arns/state/mod.rs:648` |
| 3 | account `version` type | `u8` | **`SchemaVersion` (3×u8)** | `state.rs:229` |
| 3 | `AntControllers.version` | (omitted) | **added** | `state.rs` |
| 4 | non-root `priority` | "must be > 0" | **any non-negative (≥0)** | `state.rs:651` |
| 5 | primary-name fee | single `…BASE_FEE` ~0.2 ARIO | **lease 0.2 / permabuy 1.0** | `ario-core/state/mod.rs:257,267` |
| 6 | event ABI policy ADR | ADR-017 | **ADR-018** | `DECISIONS.md` |
| 7 | expiry-close instruction | `close_expired_primary_name_request` | **`close_expired_request`** | `ario-core/lib.rs:280` |
| 9 | undername regex | `^[a-zA-Z0-9]+[a-zA-Z0-9_-]*$` | **`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`** | `state.rs:532` |

**Why #1 drifted:** the ANT limits were intentionally reduced on 2026-05-21 for migration rent savings (snapshot audit showed p99 well under the new caps); the specs' 2026-05-11 "audit corrections" predate that. **Why #2 drifted:** ADR-024 standardized one full-size registry (`INITIAL_CAPACITY = 50,000`, expandable post-deploy to ~200K) and retired the `devnet-shrunk` variant — so the prior "200,000 (not 50,000)" note was backwards.

Each file also gets a new changelog row, and (per a related request) two `arweave.net` references were removed: the whitepaper link → `https://html_whitepaper.ar.io/`, and an example host → `ardrive.ar.io`. The overview now notes ArNS was "previously the Arweave Name System" at the first acronym expansion.

## Out of scope (separate repo, flagged for follow-up)
Matching stale references exist in the contracts repo and want their own PR: `CLAUDE.md` & `docs/EVENTS.md` ("NameRegistry 200,000" / event policy "ADR-017"), and `ario-ant/state.rs` struct doc-comments still reading "max 256 / max 8 / max 10".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AR.IO Name System specification with contract-drift corrections.
  * Adjusted validation constraints: description field reduced to 128 characters max, keywords limited to 3 (down from 8), and priority field now accepts non-negative integers for non-root records.
  * Reduced maximum controllers per ANT to 4.
  * Clarified NameRegistry initial capacity as 50,000 expandable slots.
  * Updated branding and reference links throughout documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->